### PR TITLE
Added support of ItemNames configuration filter for Enchant/Augment

### DIFF
--- a/EpicLoot/Crafting/EnchantCostsConfig.cs
+++ b/EpicLoot/Crafting/EnchantCostsConfig.cs
@@ -35,6 +35,7 @@ namespace EpicLoot.Crafting
     {
         public ItemRarity Rarity;
         public List<string> ItemTypes = new List<string>();
+        public List<string> ItemNames = new List<string>();
         public List<ItemAmountConfig> Cost = new List<ItemAmountConfig>();
     }
 
@@ -43,6 +44,7 @@ namespace EpicLoot.Crafting
     {
         public ItemRarity Rarity;
         public List<string> ItemTypes = new List<string>();
+        public List<string> ItemNames = new List<string>();
         public List<ItemAmountConfig> Cost = new List<ItemAmountConfig>();
     }
 

--- a/EpicLoot/Crafting/EnchantCostsHelper.cs
+++ b/EpicLoot/Crafting/EnchantCostsHelper.cs
@@ -85,6 +85,7 @@ namespace EpicLoot.Crafting
         public static List<ItemAmountConfig> GetEnchantCost(ItemDrop.ItemData item, ItemRarity rarity)
         {
             var type = item.m_shared.m_itemType;
+            var name = item.m_shared.m_name;
 
             var configEntry = Config.EnchantCosts.Find(x => {
                 if (x.Rarity != rarity)
@@ -93,6 +94,11 @@ namespace EpicLoot.Crafting
                 }
 
                 if (x.ItemTypes?.Count > 0 && !x.ItemTypes.Contains(type.ToString()))
+                {
+                    return false;
+                }
+
+                if (x.ItemNames?.Count > 0 && !x.ItemNames.Contains(name))
                 {
                     return false;
                 }
@@ -106,6 +112,7 @@ namespace EpicLoot.Crafting
         public static List<ItemAmountConfig> GetAugmentCost(ItemDrop.ItemData item, ItemRarity rarity, int recipeEffectIndex)
         {
             var type = item.m_shared.m_itemType;
+            var name = item.m_shared.m_name;
 
             var configEntry = Config.AugmentCosts.Find(x => {
                 if (x.Rarity != rarity)
@@ -114,6 +121,11 @@ namespace EpicLoot.Crafting
                 }
 
                 if (x.ItemTypes?.Count > 0 && !x.ItemTypes.Contains(type.ToString()))
+                {
+                    return false;
+                }
+
+                if (x.ItemNames?.Count > 0 && !x.ItemNames.Contains(name))
                 {
                     return false;
                 }


### PR DESCRIPTION
Motivation: the possibility to use ItemNames filter in enchantcosts.json, for example, when someone wants to have different consts not only by rarities and types but for item grades also (for example, rare club and rare iron mace should have different costs).
Backward compatibility: should not affect anyone using default enchantcosts.json file