### PR TITLE
Summing of effects that should not reach 100%/1.0 values with diminishing returns formula

### DIFF
--- a/EpicLoot/MagicItemComponent.cs
+++ b/EpicLoot/MagicItemComponent.cs
@@ -668,6 +668,7 @@ namespace EpicLoot
                 MagicEffectType.AddSpiritResistancePercentage,
                 MagicEffectType.AddElementalResistancePercentage,
                 MagicEffectType.AvoidDamageTaken,
+                MagicEffectType.AvoidDamageTakenLowHealth,
                 MagicEffectType.ModifyAttackStaminaUse,
                 MagicEffectType.ModifyBlockStaminaUse,
                 MagicEffectType.ModifyJumpStaminaUse,

--- a/EpicLoot/MagicItemEffects/AvoidDamageTaken.cs
+++ b/EpicLoot/MagicItemEffects/AvoidDamageTaken.cs
@@ -13,13 +13,24 @@ namespace EpicLoot.MagicItemEffects
 			var attacker = hit.GetAttacker();
 			if (__instance is Player player && attacker != null && attacker != __instance)
 			{
-				var avoidanceChance = 0f;
-				ModifyWithLowHealth.Apply(player, MagicEffectType.AvoidDamageTaken, effect =>
-				{
-                    avoidanceChance += player.GetTotalActiveMagicEffectValue(effect, 0.01f);
-                });
+				var avoidancePercent = player.GetTotalActiveMagicEffectValue(MagicEffectType.AvoidDamageTaken, 1.0f);
+                var avoidancePercentLowHealth = ModifyWithLowHealth.PlayerHasLowHealth(player) ? player.GetTotalActiveMagicEffectValue(MagicEffectType.AvoidDamageTakenLowHealth, 1.0f) : 0.0f;
 
-				return !(Random.Range(0f, 1f) < avoidanceChance);
+				float min, max;
+				if(avoidancePercent > avoidancePercentLowHealth)
+				{
+					min = avoidancePercentLowHealth;
+					max = avoidancePercent;
+				}
+				else
+				{
+                    min = avoidancePercent;
+                    max = avoidancePercentLowHealth;
+                }
+
+				float avoidanceChance = (max + (100.0f - max) * min * 0.01f) * 0.01f;
+
+                return !(Random.Range(0f, 1f) < avoidanceChance);
 			}
 
 			return true;

--- a/EpicLoot/MagicItemEffects/ModifyResistance.cs
+++ b/EpicLoot/MagicItemEffects/ModifyResistance.cs
@@ -47,29 +47,29 @@ namespace EpicLoot.MagicItemEffects
 			    return;
 		    }
 
-		    float sum(params string[] effects)
-		    {
-			    float value = 1;
-			    foreach (var effect in effects)
-			    {
-				    value -= player.GetTotalActiveMagicEffectValue(effect, 0.01f);
-			    }
+            float resultingDamageCoeff(string eff1, string eff2)
+            {
+                float totalSum = PlayerExtensions.GetEffectDiminishingReturnsTotalValue(new List<float>()
+                {
+                    player.GetTotalActiveMagicEffectValue(eff1, 0.01f),
+                    player.GetTotalActiveMagicEffectValue(eff2, 0.01f)
+                });
 
-			    return Math.Max(value, 0);
-		    }
+                return 1.0f - totalSum;
+            }
 
-		    // elemental resistances
-		    hit.m_damage.m_fire *= sum(MagicEffectType.AddFireResistancePercentage, MagicEffectType.AddElementalResistancePercentage);
-		    hit.m_damage.m_frost *= sum(MagicEffectType.AddFrostResistancePercentage, MagicEffectType.AddElementalResistancePercentage);
-		    hit.m_damage.m_lightning *= sum(MagicEffectType.AddLightningResistancePercentage, MagicEffectType.AddElementalResistancePercentage);
-		    hit.m_damage.m_poison *= sum(MagicEffectType.AddPoisonResistancePercentage, MagicEffectType.AddElementalResistancePercentage);
-		    hit.m_damage.m_spirit *= sum(MagicEffectType.AddSpiritResistancePercentage, MagicEffectType.AddElementalResistancePercentage);
+            // elemental resistances
+            hit.m_damage.m_fire *= resultingDamageCoeff(MagicEffectType.AddFireResistancePercentage, MagicEffectType.AddElementalResistancePercentage);
+		    hit.m_damage.m_frost *= resultingDamageCoeff(MagicEffectType.AddFrostResistancePercentage, MagicEffectType.AddElementalResistancePercentage);
+		    hit.m_damage.m_lightning *= resultingDamageCoeff(MagicEffectType.AddLightningResistancePercentage, MagicEffectType.AddElementalResistancePercentage);
+		    hit.m_damage.m_poison *= resultingDamageCoeff(MagicEffectType.AddPoisonResistancePercentage, MagicEffectType.AddElementalResistancePercentage);
+		    hit.m_damage.m_spirit *= resultingDamageCoeff(MagicEffectType.AddSpiritResistancePercentage, MagicEffectType.AddElementalResistancePercentage);
 		    
 		    // physical resistances
-		    hit.m_damage.m_blunt *= sum(MagicEffectType.AddBluntResistancePercentage, MagicEffectType.AddPhysicalResistancePercentage);
-		    hit.m_damage.m_slash *= sum(MagicEffectType.AddSlashingResistancePercentage, MagicEffectType.AddPhysicalResistancePercentage);
-		    hit.m_damage.m_pierce *= sum(MagicEffectType.AddPiercingResistancePercentage, MagicEffectType.AddPhysicalResistancePercentage);
-		    hit.m_damage.m_chop *= sum(MagicEffectType.AddChoppingResistancePercentage, MagicEffectType.AddPhysicalResistancePercentage);
+		    hit.m_damage.m_blunt *= resultingDamageCoeff(MagicEffectType.AddBluntResistancePercentage, MagicEffectType.AddPhysicalResistancePercentage);
+		    hit.m_damage.m_slash *= resultingDamageCoeff(MagicEffectType.AddSlashingResistancePercentage, MagicEffectType.AddPhysicalResistancePercentage);
+		    hit.m_damage.m_pierce *= resultingDamageCoeff(MagicEffectType.AddPiercingResistancePercentage, MagicEffectType.AddPhysicalResistancePercentage);
+		    hit.m_damage.m_chop *= resultingDamageCoeff(MagicEffectType.AddChoppingResistancePercentage, MagicEffectType.AddPhysicalResistancePercentage);
 	    }
     }
 }

--- a/EpicLoot/MagicItemEffects/ReduceWeight.cs
+++ b/EpicLoot/MagicItemEffects/ReduceWeight.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using System;
 
 namespace EpicLoot.MagicItemEffects
 {
@@ -14,7 +15,7 @@ namespace EpicLoot.MagicItemEffects
             }
             else if (__instance.HasMagicEffect(MagicEffectType.ReduceWeight))
             {
-                var totalWeightReduction = __instance.GetMagicItem().GetTotalEffectValue(MagicEffectType.ReduceWeight, 0.01f);
+                var totalWeightReduction = Math.Min(__instance.GetMagicItem().GetTotalEffectValue(MagicEffectType.ReduceWeight, 0.01f), 1.0f);
                 __result *= 1.0f - totalWeightReduction;
             }
         }

--- a/EpicLoot/TextsDialog_Patch.cs
+++ b/EpicLoot/TextsDialog_Patch.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using EpicLoot.Adventure;
@@ -55,7 +56,7 @@ namespace EpicLoot
             {
                 var effectType = entry.Key;
                 var effectDef = MagicItemEffectDefinitions.Get(effectType);
-                var sum = entry.Value.Sum(x => x.Key.EffectValue);
+                float sum = (float)Math.Round(PlayerExtensions.GetEffectDiminishingReturnsTotalValue(entry.Value.Select(x => x.Key.EffectValue).ToList(), effectType));
                 var totalEffectText = MagicItem.GetEffectText(effectDef, sum);
                 var highestRarity = (ItemRarity) entry.Value.Max(x => (int) x.Value.GetRarity());
 


### PR DESCRIPTION
Motivation: there are several effects that on reaching 100%/1.0 or above value are leading to incorrect behavior.
What actually done:
1) for the following effects
                MagicEffectType.AddPhysicalResistancePercentage,
                MagicEffectType.AddBluntResistancePercentage,
                MagicEffectType.AddSlashingResistancePercentage,
                MagicEffectType.AddPiercingResistancePercentage,
                MagicEffectType.AddChoppingResistancePercentage,
                MagicEffectType.AddFireResistancePercentage,
                MagicEffectType.AddFrostResistancePercentage,
                MagicEffectType.AddLightningResistancePercentage,
                MagicEffectType.AddPoisonResistancePercentage,
                MagicEffectType.AddSpiritResistancePercentage,
                MagicEffectType.AddElementalResistancePercentage,
                MagicEffectType.AvoidDamageTaken,
                MagicEffectType.AvoidDamageTakenLowHealth,
                MagicEffectType.ModifyAttackStaminaUse,
                MagicEffectType.ModifyBlockStaminaUse,
                MagicEffectType.ModifyJumpStaminaUse,
                MagicEffectType.ModifySprintStaminaUse,
                MagicEffectType.Slow
the formula of their summing from different items changed. Each item value is capped at 0.9, then values are ordered from the max one to min one. Max is taken as sum, remaining ones applied as sum = sum + (1.0 - sum) * effect. For example, two effects with values 0.9 and 0.9 will sum not as 1.8 but as 0.9 + 0.1 * 0.9 = 0.99. Other example: effects with values 0.1 and 0.1 will sum not as 0.2 but as 0.1 + 0.9 * 0.1 = 0.19.
2) Fixed ReduceWeight effect could reach values > 1.0.
3) Updated visual hint for the effect total value.

Backward compatibility: affects all users, theoretically can change the experience of the users using custom items or effects achieving elemental immunity etc. However, for the ones using default values in configuration files (that are in general very low in comparison with threshold of 0.9), changes are minor.

