### PR TITLE
Changed item gating with dropping item materials instead

### DIFF
--- a/EpicLoot/LootRoller.cs
+++ b/EpicLoot/LootRoller.cs
@@ -270,60 +270,72 @@ namespace EpicLoot
                 var itemName = !string.IsNullOrEmpty(lootDrop?.Item) ? lootDrop.Item : "Invalid Item Name";
                 var rarityLength = lootDrop?.Rarity?.Length != null ? lootDrop.Rarity.Length : -1;
                 EpicLoot.Log($"Item: {itemName} - Rarity Count: {rarityLength} - Weight: {lootDrop.Weight}");
-                
-                if (!cheatsActive && EpicLoot.ItemsToMaterialsDropRatio.Value > 0)
+
+                var itemID = (CheatDisableGating) ? lootDrop.Item : GatedItemTypeHelper.GetGatedItemID(lootDrop.Item);
+
+                bool ReplaceWithMats()
                 {
-                    var clampedConvertRate = Mathf.Clamp(EpicLoot.ItemsToMaterialsDropRatio.Value, 0.0f, 1.0f);
-                    var replaceWithMats = Random.Range(0.0f, 1.0f) < clampedConvertRate;
-                    if (replaceWithMats)
+                    if (itemID == null)
                     {
-                        GameObject prefab = null;
+                        return true;
+                    }
 
-                        try
-                        {
-                            prefab = ObjectDB.instance.GetItemPrefab(lootDrop.Item);
-                        }
-                        catch (Exception e)
-                        {
-                            EpicLoot.LogWarning($"Unable to get Prefab for [{lootDrop.Item}]. Continuing.");
-                            EpicLoot.LogWarning($"Error: {e.Message}");
-                        }
+                    if (!cheatsActive && EpicLoot.ItemsToMaterialsDropRatio.Value > 0)
+                    {
+                        var clampedConvertRate = Mathf.Clamp(EpicLoot.ItemsToMaterialsDropRatio.Value, 0.0f, 1.0f);
+                        return Random.Range(0.0f, 1.0f) < clampedConvertRate;
+                    }
 
-                        if (prefab != null)
+                    return false;
+                };
+
+                if (ReplaceWithMats())
+                {
+                    GameObject prefab = null;
+
+                    try
+                    {
+                        prefab = ObjectDB.instance.GetItemPrefab(lootDrop.Item);
+                    }
+                    catch (Exception e)
+                    {
+                        EpicLoot.LogWarning($"Unable to get Prefab for [{lootDrop.Item}]. Continuing.");
+                        EpicLoot.LogWarning($"Error: {e.Message}");
+                    }
+
+                    if (prefab != null)
+                    {
+                        var rarity = RollItemRarity(lootDrop, luckFactor);
+                        var itemType = prefab.GetComponent<ItemDrop>().m_itemData.m_shared.m_itemType;
+                        var disenchantProducts = EnchantCostsHelper.GetSacrificeProducts(true, itemType, rarity);
+                        if (disenchantProducts != null)
                         {
-                            var rarity = RollItemRarity(lootDrop, luckFactor);
-                            var itemType = prefab.GetComponent<ItemDrop>().m_itemData.m_shared.m_itemType;
-                            var disenchantProducts = EnchantCostsHelper.GetSacrificeProducts(true, itemType, rarity);
-                            if (disenchantProducts != null)
+                            foreach (var itemAmountConfig in disenchantProducts)
                             {
-                                foreach (var itemAmountConfig in disenchantProducts)
+                                GameObject materialPrefab = null;
+                                try
                                 {
-                                    GameObject materialPrefab = null;
-                                    try
-                                    {
-                                        materialPrefab = ObjectDB.instance.GetItemPrefab(itemAmountConfig.Item);
-                                    }
-                                    catch (Exception e)
-                                    {
-                                        EpicLoot.LogWarning($"Unable to get Disenchant Product Prefab for [{itemAmountConfig?.Item ?? "Invalid Item"}]. Continuing.");
-                                        EpicLoot.LogWarning($"Error: {e.Message}");
-                                    }
-
-                                    if (materialPrefab == null) continue;
-                                    var materialItem = SpawnLootForDrop(materialPrefab, dropPoint, true);
-                                    var materialItemDrop = materialItem.GetComponent<ItemDrop>();
-                                    materialItemDrop.m_itemData.m_stack = itemAmountConfig.Amount;
-                                    if (materialItemDrop.m_itemData.IsMagicCraftingMaterial())
-                                        materialItemDrop.m_itemData.m_variant = EpicLoot.GetRarityIconIndex(rarity);
-                                    results.Add(materialItem);
+                                    materialPrefab = ObjectDB.instance.GetItemPrefab(itemAmountConfig.Item);
                                 }
+                                catch (Exception e)
+                                {
+                                    EpicLoot.LogWarning($"Unable to get Disenchant Product Prefab for [{itemAmountConfig?.Item ?? "Invalid Item"}]. Continuing.");
+                                    EpicLoot.LogWarning($"Error: {e.Message}");
+                                }
+
+                                if (materialPrefab == null) continue;
+                                var materialItem = SpawnLootForDrop(materialPrefab, dropPoint, true);
+                                var materialItemDrop = materialItem.GetComponent<ItemDrop>();
+                                materialItemDrop.m_itemData.m_stack = itemAmountConfig.Amount;
+                                if (materialItemDrop.m_itemData.IsMagicCraftingMaterial())
+                                    materialItemDrop.m_itemData.m_variant = EpicLoot.GetRarityIconIndex(rarity);
+                                results.Add(materialItem);
                             }
                         }
-
-                        continue;
                     }
+
+                    continue;
                 }
-                var itemID = (CheatDisableGating) ? lootDrop.Item : GatedItemTypeHelper.GetGatedItemID(lootDrop.Item);
 
                 GameObject itemPrefab = null;
 


### PR DESCRIPTION
Motivation: gating can be unnatural and provide unexpected drop when each mob is configured with its own dedicated loot. Gating doesn't provide "proper" compensation if the current tier mob drops the item with less probability than the previous tier one drops the result of gating as its normal drop. Changing gating of the item that is not allowed to drop yet to forcible breaking it into materials and dropping them instead looks as more universal and "item lore friendly" solution. In a real gameplay scenario the player would anyway disassembled or trashed the gated item (but had less materials) in most of the cases.

Backward compatibility: since gating is a side mechnic to resolve issue when item is not allowed yet (to avoid empty drop), doesn't affect most of the gameplay related to loot much.