### PR TITLE
Changed Riches effect to drop only coins to avoid inventory cluttering

### DIFF
--- a/EpicLoot/MagicItemEffects/Riches.cs
+++ b/EpicLoot/MagicItemEffects/Riches.cs
@@ -11,11 +11,7 @@ namespace EpicLoot.MagicItemEffects
 	{
         public static readonly Dictionary<GameObject, int> RichesTable = new Dictionary<GameObject, int>
         {
-            { ObjectDB.instance.GetItemPrefab("SilverNecklace"), 30 },
-            { ObjectDB.instance.GetItemPrefab("Ruby"), 20 },
-            { ObjectDB.instance.GetItemPrefab("AmberPearl"), 10 },
-            { ObjectDB.instance.GetItemPrefab("Amber"), 5 },
-            { ObjectDB.instance.GetItemPrefab("Coins"), 1 },
+            { ObjectDB.instance.GetItemPrefab("Coins"), 1 }
         };
 
         [UsedImplicitly]
@@ -24,8 +20,8 @@ namespace EpicLoot.MagicItemEffects
 			var playerList = new List<Player>();
 			Player.GetPlayersInRange(__instance.m_character.transform.position, 100f, playerList);
 
-			var richesAmount = Random.Range(10, 100);
-			var richesChance = playerList.Sum(player => player.m_nview.GetZDO().GetInt("el-rch")) * 0.01f;
+            var richesAmount = Random.Range(2, 10) * Random.Range(2, 10);
+            var richesChance = playerList.Sum(player => player.m_nview.GetZDO().GetInt("el-rch")) * 0.01f;
 			if (richesChance > 1)
 			{
 				richesAmount = Mathf.RoundToInt(richesAmount * richesChance);


### PR DESCRIPTION
Motivation: one of the main problems of Valheim is cluttering (random mob has spawned and aggro, you've killed the random mob, now you need to put 1 wood, 1 stone, 1 eye and 1 trophy into the chest again). The ability to drop necklaces and amber, despite being fun on the paper, makes Riches to be the most annoying effect in the game.

Backward compatibility: theoretically can effect users who relied on specific drop from Riches but it's definitely not about default Epic Loot configurations.