### PR TITLE
Enchantment table incorrect upgrades level when "Upgrades Active = false" bugs fixes

### DIFF
--- a/EpicLoot-UnityLib/EnchantingTable.cs
+++ b/EpicLoot-UnityLib/EnchantingTable.cs
@@ -11,7 +11,7 @@ namespace EpicLoot_UnityLib
         public const string DisplayNameLocID = "mod_epicloot_assets_enchantingtable";
         public const int FeatureUnavailableSentinel = -2;
         public const int FeatureLockedSentinel = -1;
-        public const int FeatureLevelOne = 1;
+        public const int FeatureLevelOne = 0;
 
         public GameObject EnchantingUIPrefab;
 

--- a/EpicLoot-UnityLib/FeatureStatus3D.cs
+++ b/EpicLoot-UnityLib/FeatureStatus3D.cs
@@ -27,6 +27,12 @@ namespace EpicLoot_UnityLib
                 UnlockedObject.SetActive(featureIsUnlocked);
 
             var currentLevel = SourceTable.GetFeatureLevel(Feature);
+            if(!EnchantingTable.UpgradesActive(Feature, out bool featureActive))
+            {
+                // To improve table appearance when no upgrades are available ever
+                currentLevel = 1;
+            }
+
             for (var index = 0; index < LevelObjects.Length; index++)
             {
                 var levelObject = LevelObjects[index];

--- a/EpicLoot/CraftingV2/EnchantingTable_Patch.cs
+++ b/EpicLoot/CraftingV2/EnchantingTable_Patch.cs
@@ -15,6 +15,11 @@ namespace EpicLoot.CraftingV2
             if (table == null)
                 return;
 
+            if(!EpicLoot.EnchantingTableUpgradesActive.Value)
+            {
+                return;
+            }
+
             foreach (EnchantingFeature feature in Enum.GetValues(typeof(EnchantingFeature)))
             {
                 if (!table.IsFeatureAvailable(feature) || table.IsFeatureLocked(feature))


### PR DESCRIPTION
Motivation: when "Upgrades Active = false" config setting was set, it led to the following bugs and issues:
- when enchantment level is destroyed, it drops all level 1 upgrades materials. Thus, a player can build and destroy Enchantment table multiple times gaining unlimited amount of surtling cores, coins, tokens etc
- default value of upgrades 1 is inconsistent with the goal of the config setting itself, that is, the player still sees and gets upgrades   bonuses for level 1 upgrades but not being able to improve them. More reasonable behavior is not having any information about upgrades at all and don't gain any effects from them (theoretically, default bonuses for level 1 upgrades can change in the future and this will change the experience of "Upgrades Active = false" users also which is illogical).

What actually done:
- changed default "Upgrades Active = false" enchanment table upgrades level to 0
- fixed the logic of calculation enchanment table drops on its destroying
- made visual appearance of enchantment table in the game when "Upgrades Active = false" to mimic level 1 upgrades since level 0 enchantment table looks rather empty (maybe it was the main reason for previous level 1 upgrades set by default for "Upgrades Active = false"  )

Backward compatibility: should not provide issues for the existent users