### PR TITLE
Modify attack speed effect recently introduced bug fix

### DIFF
--- a/EpicLoot/MagicItemEffects/ModifyAttackSpeed.cs
+++ b/EpicLoot/MagicItemEffects/ModifyAttackSpeed.cs
@@ -1,6 +1,5 @@
 ﻿using HarmonyLib;
 using JetBrains.Annotations;
-using EpicLoot;
 
 namespace EpicLoot.MagicItemEffects
 {

--- a/EpicLoot/MagicItemEffects/ModifyAttackSpeed.cs
+++ b/EpicLoot/MagicItemEffects/ModifyAttackSpeed.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using JetBrains.Annotations;
+using EpicLoot;
 
 namespace EpicLoot.MagicItemEffects
 {
@@ -18,13 +19,16 @@ namespace EpicLoot.MagicItemEffects
             {
                 return speed;
             }
+
+            double bonus = 0.0;
             
             ModifyWithLowHealth.Apply(player, MagicEffectType.ModifyAttackSpeed, effect =>
             {
-                
-                speed += player.GetTotalActiveMagicEffectValue(effect, 0.01f);
+                bonus += player.GetTotalActiveMagicEffectValue(effect, 0.01f);
             });
-            
+
+            speed *= (1.0 + bonus);
+
             return speed;
         }
         [UsedImplicitly]


### PR DESCRIPTION
Motivation: looks like 18.09.2023 commit added bug making attack speed modifier to work in additive not multiplicative way. That results in modificator working illogical (the same value for knives and hammers work very differently) and also having choppy animation (changing real speed on the fly) even for particular weapon when it consists of several different length frames.

Backward compatibility: naturally affects every user but should not break anything