### PR TITLE
Implemented ValuesPerItemName filter for magiceffects

### DIFF
--- a/EpicLoot/Crafting/AugmentChoiceDialog.cs
+++ b/EpicLoot/Crafting/AugmentChoiceDialog.cs
@@ -137,7 +137,7 @@ namespace EpicLoot.Crafting
                 var button = EffectChoiceButtons[index];
                 button.gameObject.SetActive(true);
                 var text = button.GetComponentInChildren<TMP_Text>();
-                text.text = Localization.instance.Localize((index == 0 ? "<color=white>($mod_epicloot_augment_keep)</color> " : "") + MagicItem.GetEffectText(effect, rarity, true));
+                text.text = Localization.instance.Localize((index == 0 ? "<color=white>($mod_epicloot_augment_keep)</color> " : "") + MagicItem.GetEffectText(effect, rarity, fromItem.m_shared.m_name, true));
                 text.color = rarityColor;
 
                 if (EpicLoot.HasAuga)

--- a/EpicLoot/Crafting/AugmentHelper.cs
+++ b/EpicLoot/Crafting/AugmentHelper.cs
@@ -169,7 +169,7 @@ namespace EpicLoot.Crafting
             if (recipe.EffectIndex >= 0 && recipe.EffectIndex < magicItem.Effects.Count)
             {
                 var currentEffectDef = MagicItemEffectDefinitions.Get(magicItem.Effects[recipe.EffectIndex].EffectType);
-                valuelessEffect = currentEffectDef.GetValuesForRarity(rarity) == null;
+                valuelessEffect = currentEffectDef.GetValuesForRarity(rarity, item.m_shared.m_name) == null;
             }
 
             return MagicItemEffectDefinitions.GetAvailableEffects(item.Extended(), item.GetMagicItem(), valuelessEffect ? -1 : recipe.EffectIndex);
@@ -179,7 +179,7 @@ namespace EpicLoot.Crafting
         {
             var pip = EpicLoot.GetMagicEffectPip(magicItem.IsEffectAugmented(i));
             bool free = EnchantCostsHelper.EffectIsDeprecated(augmentableEffects[i].EffectType);
-            return $"{pip} {Localization.instance.Localize(MagicItem.GetEffectText(augmentableEffects[i], rarity, true))}{(free ? " [<color=yellow>*FREE</color>]" : "")}";
+            return $"{pip} {Localization.instance.Localize(MagicItem.GetEffectText(augmentableEffects[i], rarity, magicItem.ItemName, true))}{(free ? " [<color=yellow>*FREE</color>]" : "")}";
         }
 
         public static List<KeyValuePair<ItemDrop, int>> GetAugmentCosts(ItemDrop.ItemData item, int recipeEffectIndex)

--- a/EpicLoot/Crafting/AugmentsAvailableDialog.cs
+++ b/EpicLoot/Crafting/AugmentsAvailableDialog.cs
@@ -72,7 +72,7 @@ namespace EpicLoot.Crafting
 
                 foreach (var effectDef in availableEffects)
                 {
-                    var values = effectDef.GetValuesForRarity(item.GetRarity());
+                    var values = effectDef.GetValuesForRarity(item.GetRarity(), item.m_shared.m_name);
                     var valueDisplay = values != null ? Mathf.Approximately(values.MinValue, values.MaxValue) ? $"{values.MinValue}" : $"({values.MinValue}-{values.MaxValue})" : "";
                     t.AppendLine($"‣ {string.Format(Localization.instance.Localize(effectDef.DisplayText), valueDisplay)}");
                 }

--- a/EpicLoot/CraftingV2/EnchantingUIController.cs
+++ b/EpicLoot/CraftingV2/EnchantingUIController.cs
@@ -388,7 +388,7 @@ namespace EpicLoot.CraftingV2
             
             foreach (var effectDef in availableEffects)
             {
-                var values = effectDef.GetValuesForRarity(rarity);
+                var values = effectDef.GetValuesForRarity(rarity, item.m_shared.m_name);
                 var valueDisplay = values != null ? Mathf.Approximately(values.MinValue, values.MaxValue) ? $"{values.MinValue}" : $"({values.MinValue}-{values.MaxValue})" : "";
                 sb.AppendLine($"‣ {string.Format(Localization.instance.Localize(effectDef.DisplayText), valueDisplay)}");
             }
@@ -520,7 +520,7 @@ namespace EpicLoot.CraftingV2
             if (augmentindex >= 0 && augmentindex < magicItem.Effects.Count)
             {
                 var currentEffectDef = MagicItemEffectDefinitions.Get(magicItem.Effects[augmentindex].EffectType);
-                valuelessEffect = currentEffectDef.GetValuesForRarity(rarity) == null;
+                valuelessEffect = currentEffectDef.GetValuesForRarity(rarity, item.m_shared.m_name) == null;
             }
 
             var availableEffects = MagicItemEffectDefinitions.GetAvailableEffects(item.Extended(), item.GetMagicItem(), valuelessEffect ? -1 : augmentindex);
@@ -529,7 +529,7 @@ namespace EpicLoot.CraftingV2
             sb.Append($"<color={rarityColor}>");
             foreach (var effectDef in availableEffects)
             {
-                var values = effectDef.GetValuesForRarity(item.GetRarity());
+                var values = effectDef.GetValuesForRarity(item.GetRarity(), item.m_shared.m_name);
                 var valueDisplay = values != null ? Mathf.Approximately(values.MinValue, values.MaxValue) ? $"{values.MinValue}" : $"({values.MinValue}-{values.MaxValue})" : "";
                 sb.AppendLine($"‣ {string.Format(Localization.instance.Localize(effectDef.DisplayText), valueDisplay)}");
             }

--- a/EpicLoot/LootRoller.cs
+++ b/EpicLoot/LootRoller.cs
@@ -351,7 +351,7 @@ namespace EpicLoot
                     var magicItem = RollMagicItem(lootDrop, itemData, luckFactor);
                     if (CheatForceMagicEffect)
                     {
-                        AddDebugMagicEffects(magicItem);
+                        AddDebugMagicEffects(magicItem, itemData.m_shared.m_name);
                     }
                     magicItemComponent.SetMagicItem(magicItem);
                     itemDrop.m_itemData = itemData;
@@ -464,7 +464,7 @@ namespace EpicLoot
                 rarity = ItemRarity.Legendary;
             }
 
-            var magicItem = new MagicItem { Rarity = rarity };
+            var magicItem = new MagicItem { Rarity = rarity, ItemName = baseItem.m_shared.m_name };
 
             var effectCount = CheatEffectCount >= 1 ? CheatEffectCount : RollEffectCountPerRarity(magicItem.Rarity);
 
@@ -512,7 +512,7 @@ namespace EpicLoot
                             continue;
                         }
 
-                        var effect = RollEffect(effectDef, ItemRarity.Legendary, guaranteedMagicEffect.Values);
+                        var effect = RollEffect(effectDef, ItemRarity.Legendary, baseItem.m_shared.m_name, guaranteedMagicEffect.Values);
                         magicItem.Effects.Add(effect);
                         effectCount--;
                     }
@@ -532,7 +532,7 @@ namespace EpicLoot
                 _weightedEffectTable.Setup(availableEffects, x => x.SelectionWeight);
                 var effectDef = _weightedEffectTable.Roll();
 
-                var effect = RollEffect(effectDef, magicItem.Rarity);
+                var effect = RollEffect(effectDef, magicItem.Rarity, baseItem.m_shared.m_name);
                 magicItem.Effects.Add(effect);
             }
 
@@ -612,10 +612,10 @@ namespace EpicLoot
             return result;
         }
 
-        public static MagicItemEffect RollEffect(MagicItemEffectDefinition effectDef, ItemRarity itemRarity, MagicItemEffectDefinition.ValueDef valuesOverride = null)
+        public static MagicItemEffect RollEffect(MagicItemEffectDefinition effectDef, ItemRarity itemRarity, string itemName, MagicItemEffectDefinition.ValueDef valuesOverride = null)
         {
             float value = MagicItemEffect.DefaultValue;
-            var valuesDef = valuesOverride ?? effectDef.GetValuesForRarity(itemRarity);
+            var valuesDef = valuesOverride ?? effectDef.GetValuesForRarity(itemRarity, itemName);
             if (valuesDef != null)
             {
                 value = valuesDef.MinValue;
@@ -630,7 +630,8 @@ namespace EpicLoot
             return new MagicItemEffect(effectDef.Type, value);
         }
 
-        public static List<MagicItemEffect> RollEffects(List<MagicItemEffectDefinition> availableEffects, ItemRarity itemRarity, int count, bool removeOnSelect = true)
+
+        public static List<MagicItemEffect> RollEffects(List<MagicItemEffectDefinition> availableEffects, ItemRarity itemRarity, string itemName, int count, bool removeOnSelect = true)
         {
             var results = new List<MagicItemEffect>();
 
@@ -644,7 +645,7 @@ namespace EpicLoot
                     EpicLoot.LogError($"EffectDef was null! RollEffects({itemRarity}, {count})");
                     continue;
                 }
-                results.Add(RollEffect(effectDef, itemRarity));
+                results.Add(RollEffect(effectDef, itemRarity, itemName));
             }
 
             return results;
@@ -818,7 +819,7 @@ namespace EpicLoot
 
             for (var i = 0; i < augmentChoices && i < availableEffects.Count; i++)
             {
-                var newEffect = RollEffects(availableEffects, rarity, 1, false).FirstOrDefault();
+                var newEffect = RollEffects(availableEffects, rarity, item.m_shared.m_name, 1, false).FirstOrDefault();
                 if (newEffect == null)
                 {
                     EpicLoot.LogError($"Rolled a null effect: item:{item.m_shared.m_name}, index:{effectIndex}");
@@ -837,12 +838,12 @@ namespace EpicLoot
             return results;
         }
 
-        public static void AddDebugMagicEffects(MagicItem item)
+        public static void AddDebugMagicEffects(MagicItem item, string itemName)
         {
             if (!string.IsNullOrEmpty(ForcedMagicEffect) && !item.HasEffect(ForcedMagicEffect))
             {
                 EpicLoot.Log($"AddDebugMagicEffect {ForcedMagicEffect}");
-                item.Effects.Add(RollEffect(MagicItemEffectDefinitions.Get(ForcedMagicEffect), item.Rarity));
+                item.Effects.Add(RollEffect(MagicItemEffectDefinitions.Get(ForcedMagicEffect), item.Rarity, itemName));
             }
         }
 

--- a/EpicLoot/MagicItem.cs
+++ b/EpicLoot/MagicItem.cs
@@ -39,7 +39,7 @@ namespace EpicLoot
     [Serializable]
     public class MagicItem
     {
-        public int Version = 2;
+        public int Version = 3;
         public ItemRarity Rarity;
         public List<MagicItemEffect> Effects = new List<MagicItemEffect>();
         public string TypeNameOverride;
@@ -48,6 +48,7 @@ namespace EpicLoot
         public string DisplayName;
         public string LegendaryID;
         public string SetID;
+        public string ItemName;
 
         public string GetItemTypeName(ItemDrop.ItemData baseItem)
         {
@@ -71,7 +72,7 @@ namespace EpicLoot
             {
                 var effect = Effects[index];
                 var pip = EpicLoot.GetMagicEffectPip(IsEffectAugmented(index));
-                tooltip.AppendLine($"{pip} {GetEffectText(effect, Rarity, showRange)}");
+                tooltip.AppendLine($"{pip} {GetEffectText(effect, Rarity, ItemName, showRange)}");
             }
 
             tooltip.Append($"</color>");
@@ -127,11 +128,11 @@ namespace EpicLoot
             return result;
         }
 
-        public static string GetEffectText(MagicItemEffect effect, ItemRarity rarity, bool showRange, string legendaryID, MagicItemEffectDefinition.ValueDef valuesOverride)
+        public static string GetEffectText(MagicItemEffect effect, ItemRarity rarity, string itemName, bool showRange, string legendaryID, MagicItemEffectDefinition.ValueDef valuesOverride)
         {
             var effectDef = MagicItemEffectDefinitions.Get(effect.EffectType);
             var result = GetEffectText(effectDef, effect.EffectValue);
-            var values = valuesOverride ?? (string.IsNullOrEmpty(legendaryID) ? effectDef.GetValuesForRarity(rarity) : UniqueLegendaryHelper.GetLegendaryEffectValues(legendaryID, effect.EffectType));
+            var values = valuesOverride ?? (string.IsNullOrEmpty(legendaryID) ? effectDef.GetValuesForRarity(rarity, itemName) : UniqueLegendaryHelper.GetLegendaryEffectValues(legendaryID, effect.EffectType));
             if (showRange && values != null)
             {
                 if (!Mathf.Approximately(values.MinValue, values.MaxValue))
@@ -142,14 +143,14 @@ namespace EpicLoot
             return result;
         }
 
-        public static string GetEffectText(MagicItemEffect effect, ItemRarity rarity, bool showRange, string legendaryID = null)
+        public static string GetEffectText(MagicItemEffect effect, ItemRarity rarity, string itemName, bool showRange, string legendaryID = null)
         {
-            return GetEffectText(effect, rarity, showRange, legendaryID, null);
+            return GetEffectText(effect, rarity, itemName, showRange, legendaryID, null);
         }
 
-        public static string GetEffectText(MagicItemEffect effect, MagicItemEffectDefinition.ValueDef valuesOverride)
+        public static string GetEffectText(MagicItemEffect effect, string itemName, MagicItemEffectDefinition.ValueDef valuesOverride)
         {
-            return GetEffectText(effect, ItemRarity.Legendary, false, null, valuesOverride);
+            return GetEffectText(effect, ItemRarity.Legendary, itemName, false, null, valuesOverride);
         }
 
         public void ReplaceEffect(int index, MagicItemEffect newEffect)

--- a/EpicLoot/MagicItemEffectDefinition.cs
+++ b/EpicLoot/MagicItemEffectDefinition.cs
@@ -300,12 +300,20 @@ namespace EpicLoot
             public ValueDef Mythic;
         }
 
+        [Serializable]
+        public class ValuesPerItemNameDef
+        {
+            public List<string> ItemNames = new List<string>();
+            public ValuesPerRarityDef ValuesPerRarity = new ValuesPerRarityDef();
+        }
+
         public string Type { get; set; }
 
         public string DisplayText = "";
         public string Description = "";
         public MagicItemEffectRequirements Requirements = new MagicItemEffectRequirements();
         public ValuesPerRarityDef ValuesPerRarity = new ValuesPerRarityDef();
+        public List<ValuesPerItemNameDef> ValuesPerItemName = new List<ValuesPerItemNameDef>();
         public float SelectionWeight = 1;
         public bool CanBeAugmented = true;
         public bool CanBeDisenchanted = true;
@@ -338,18 +346,36 @@ namespace EpicLoot
 
         public ValueDef GetValuesForRarity(ItemRarity itemRarity, string itemName)
         {
-            switch (itemRarity)
+            ValueDef ValueForRarity(ValuesPerRarityDef valuesPerRarity)
             {
-                case ItemRarity.Magic:      return ValuesPerRarity.Magic;
-                case ItemRarity.Rare:       return ValuesPerRarity.Rare;
-                case ItemRarity.Epic:       return ValuesPerRarity.Epic;
-                case ItemRarity.Legendary:  return ValuesPerRarity.Legendary;
-                case ItemRarity.Mythic:
-                    // TODO: Mythic Hookup
-                    return null;//ValuesPerRarity.Mythic;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(itemRarity), itemRarity, null);
+                switch (itemRarity)
+                {
+                    case ItemRarity.Magic: return valuesPerRarity.Magic;
+                    case ItemRarity.Rare: return valuesPerRarity.Rare;
+                    case ItemRarity.Epic: return valuesPerRarity.Epic;
+                    case ItemRarity.Legendary: return valuesPerRarity.Legendary;
+                    case ItemRarity.Mythic:
+                        // TODO: Mythic Hookup
+                        return null;//ValuesPerRarity.Mythic;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(itemRarity), itemRarity, null);
+                }
             }
+
+            if (string.IsNullOrEmpty(itemName) || ValuesPerItemName == null)
+            {
+                return ValueForRarity(ValuesPerRarity);
+            }
+
+            for (var i = 0; i < ValuesPerItemName.Count; i++)
+            {
+                if (ValuesPerItemName[i].ItemNames.Contains(itemName))
+                {
+                    return ValueForRarity(ValuesPerItemName[i].ValuesPerRarity);
+                }
+            }
+
+            return ValueForRarity(ValuesPerRarity);
         }
     }
 

--- a/EpicLoot/MagicItemEffectDefinition.cs
+++ b/EpicLoot/MagicItemEffectDefinition.cs
@@ -336,7 +336,7 @@ namespace EpicLoot
             return ValuesPerRarity.Magic != null && ValuesPerRarity.Epic != null && ValuesPerRarity.Rare != null && ValuesPerRarity.Legendary != null;
         }
 
-        public ValueDef GetValuesForRarity(ItemRarity itemRarity)
+        public ValueDef GetValuesForRarity(ItemRarity itemRarity, string itemName)
         {
             switch (itemRarity)
             {
@@ -426,7 +426,7 @@ namespace EpicLoot
                 return false;
             }
 
-            return effectDef.GetValuesForRarity(rarity) == null;
+            return effectDef.GetValuesForRarity(rarity, null) == null;
         }
     }
 }

--- a/EpicLoot/Multiplayer_Player_Patch.cs
+++ b/EpicLoot/Multiplayer_Player_Patch.cs
@@ -119,7 +119,7 @@ namespace EpicLoot
                     itemData = targetItemData.Clone();
                     itemData.m_durability = float.PositiveInfinity;
                     var magicItemComponent = itemData.Data().GetOrCreate<MagicItemComponent>();
-                    var stubMagicItem = new MagicItem { Rarity = ItemRarity.Legendary, LegendaryID = zdoLegendaryID };
+                    var stubMagicItem = new MagicItem { Rarity = ItemRarity.Legendary, ItemName = itemData.m_shared.m_name, LegendaryID = zdoLegendaryID };
                     magicItemComponent.SetMagicItem(stubMagicItem);
 
                     ForceResetVisEquipment(player, itemData);

--- a/EpicLoot/Terminal_Patch.cs
+++ b/EpicLoot/Terminal_Patch.cs
@@ -618,7 +618,7 @@ namespace EpicLoot
                 return;
             }
 
-            var replacementEffect = LootRoller.RollEffect(replacementEffectDef, magicItem.Rarity);
+            var replacementEffect = LootRoller.RollEffect(replacementEffectDef, magicItem.Rarity, itemData.m_shared.m_name);
             magicItem.Effects[index] = replacementEffect;
             itemData.SaveMagicItem(magicItem);
         }

--- a/EpicLoot/TextsDialog_Patch.cs
+++ b/EpicLoot/TextsDialog_Patch.cs
@@ -64,7 +64,7 @@ namespace EpicLoot
                 {
                     var effect = entry2.Key;
                     var item = entry2.Value;
-                    t.AppendLine($" <color=#c0c0c0ff>- {MagicItem.GetEffectText(effect, item.GetRarity(), false)} ({item.GetDecoratedName()})</color>");
+                    t.AppendLine($" <color=#c0c0c0ff>- {MagicItem.GetEffectText(effect, item.GetRarity(), item.m_shared.m_name, false)} ({item.GetDecoratedName()})</color>");
                 }
 
                 t.AppendLine();


### PR DESCRIPTION
Motivation: there are several effects with plain numbers (like +hp, +stamina, plain +hp regen) that providing the same max values (like +20 for hp) can make early game items very strong but don't matter much for the late game. Without the possibility to set effects per item name it's impossible to make leather belt, gold ring and silver ring to be distinguishable (from gameplay perspective) since they occupy the same slot and have similar effects. There is similar problem with capes - it's much harder to get late game capes but they provide basically the same bonus (except their innate abilities like preventing freezing) as early game ones since there is almost no basic armor scaling on capes at all (in comparison with any other armor).
Also, settings effects per item name will allow overall more flexible configurations (one example can be making bronze armor finally worthy in comparison with troll one just by providing the former with much better ranges for +armor effect).

> Current default configuration of just making epic and legendary items to be almost not possible to drop in early game looks as just workaround to the issue and makes loot system more plain (you just switch from magic to rare, then from rare to epic, then from epic to legendary instead of using the current advantages of each item rarity on each stage of the game - the validity of the latter requires custom configurations for magiceffects, loottables etc, of course)

Backward compatibility: requires changing of MagicItem (ItemName field required). According to my tests, works with legacy items (of course, they have outdated effects) but maybe there can be situations where new world creation (removal of old items) is required.

Example 1 of usage (magiceffects.json part):
```
{
      "Type" : "IncreaseHealth",
      "DisplayText" : "$mod_epicloot_me_increasehealth_display",
      "Description" : "$mod_epicloot_me_increasehealth_desc",
      "Requirements" : {
        "AllowedItemTypes" : [
          "Helmet",
          "Chest"
        ],
        "AllowedRarities" : [
          "Rare",
          "Epic",
          "Legendary"
        ]
      },
      "ValuesPerRarity" : {
        "Rare" :      { "MinValue" : 10, "MaxValue" : 20, "Increment" : 5 },
        "Epic" :      { "MinValue" : 20, "MaxValue" : 50, "Increment" : 5 },
        "Legendary" : { "MinValue" : 30, "MaxValue" : 40, "Increment" : 5 }
      },
      "ValuesPerItemName": [
        {
            "ItemNames": [
                "$item_helmet_leather",
                "$item_chest_rags",
                "$item_chest_leather"
            ],
            "ValuesPerRarity" : {
                "Rare" :      { "MinValue" : 5, "MaxValue" : 10, "Increment" : 5 },
                "Epic" :      { "MinValue" : 10, "MaxValue" : 20, "Increment" : 5 },
                "Legendary" : { "MinValue" : 15, "MaxValue" : 15, "Increment" : 5 }
            }
        },
        {
            "ItemNames": [
                "$item_helmet_bronze",
                "$item_helmet_trollleather",
                "$item_chest_bronze",
                "$item_chest_trollleather"
            ],
            "ValuesPerRarity" : {
                "Rare" :      { "MinValue" : 10, "MaxValue" : 15, "Increment" : 5 },
                "Epic" :      { "MinValue" : 15, "MaxValue" : 30, "Increment" : 5 },
                "Legendary" : { "MinValue" : 20, "MaxValue" : 20, "Increment" : 5 }
            }
        }
      ],
      "SelectionWeight" : 300,
      "Prefixes": [
        "$mod_epicloot_me_increasehealth_prefix1"
      ],
      "Suffixes": [
        "$mod_epicloot_me_increasehealth_suffix1"
      ]
    },
```
In the first example IncreaseHealth effect is tuned down for early game armor, more for rags, less for bronze/troll. Since there is no ValuesPerItemName filter set for any other items, they get default values from common ValuesPerRarity filter.

Example 2:
```
    {
      "Type" : "AddHealthRegen",
      "DisplayText" : "$mod_epicloot_me_addhealthregen_display",
      "Description" : "$mod_epicloot_me_addhealthregen_desc",
      "Requirements" : {
        "AllowedItemTypes" : [
          "Utility"
        ]
      },
      "ValuesPerRarity" : {
        "Magic" :     { "MinValue" : 0.5, "MaxValue" : 5, "Increment" : 0.5 },
        "Rare" :      { "MinValue" : 1.5, "MaxValue" : 3, "Increment" : 0.5 },
        "Epic" :      { "MinValue" : 2.0, "MaxValue" : 8, "Increment" : 0.5 },
        "Legendary" : { "MinValue" : 2.5, "MaxValue" : 7, "Increment" : 0.5 }
      },
      "ValuesPerItemName": [
        {
            "ItemNames": [
                "$mod_epicloot_assets_leatherbelt"
            ],
            "ValuesPerRarity" : {
                "Magic" :     { "MinValue" : 0.5, "MaxValue" : 2.5, "Increment" : 0.5 },
                "Rare" :      { "MinValue" : 1.0, "MaxValue" : 1.5, "Increment" : 0.5 },
                "Epic" :      { "MinValue" : 1.0, "MaxValue" : 4.0, "Increment" : 0.5 },
                "Legendary" : { "MinValue" : 1.5, "MaxValue" : 3.5, "Increment" : 0.5 }
            }
        },
        {
            "ItemNames": [
                "$mod_epicloot_assets_goldrubyring"
            ],
            "ValuesPerRarity" : {
                "Magic" :     { "MinValue" : 0.5, "MaxValue" : 4.0, "Increment" : 0.5 },
                "Rare" :      { "MinValue" : 1.5, "MaxValue" : 2.5, "Increment" : 0.5 },
                "Epic" :      { "MinValue" : 1.5, "MaxValue" : 6.0, "Increment" : 0.5 },
                "Legendary" : { "MinValue" : 2.0, "MaxValue" : 5.5, "Increment" : 0.5 }
            }
        },
        {
            "ItemNames": [
                "$mod_epicloot_assets_silverring"
            ],
            "ValuesPerRarity" : {
                "Magic" :     { "MinValue" : 0.5, "MaxValue" : 5, "Increment" : 0.5 },
                "Rare" :      { "MinValue" : 1.5, "MaxValue" : 3, "Increment" : 0.5 },
                "Epic" :      { "MinValue" : 2.0, "MaxValue" : 8, "Increment" : 0.5 },
                "Legendary" : { "MinValue" : 2.5, "MaxValue" : 7, "Increment" : 0.5 }
            }
        }
      ],
      "SelectionWeight" : 4,
      "Prefixes": [
        "$mod_epicloot_me_addhealthregen_prefix1"
      ],
      "Suffixes": [
        "$mod_epicloot_me_addhealthregen_suffix1"
      ]
    },
```
Sets different plain +hp regen for different Utility items.