### PR TITLE
Implemented DistanceLoot config parameter for loottables.json

### DIFF
--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -1483,7 +1483,7 @@ namespace EpicLoot
             for (var i = 0; i < limit; i++)
             {
                 var level = i + 1;
-                var dropTable = LootRoller.GetDropsForLevel(lootTable, level, false);
+                var dropTable = LootRoller.GetDropsForLevelOrDistance(lootTable, level, 0, false);
                 if (dropTable == null || dropTable.Count == 0)
                 {
                     continue;
@@ -1513,7 +1513,7 @@ namespace EpicLoot
             for (var i = 0; i < limit; i++)
             {
                 var level = i + 1;
-                var lootList = LootRoller.GetLootForLevel(lootTable, level, false);
+                var lootList = LootRoller.GetLootForLevelOrDistance(lootTable, level, 0, false);
                 if (ArrayUtils.IsNullOrEmpty(lootList))
                 {
                     continue;

--- a/EpicLoot/LootConfig.cs
+++ b/EpicLoot/LootConfig.cs
@@ -20,6 +20,14 @@ namespace EpicLoot
     }
 
     [Serializable]
+    public class DistanceLootDef
+    {
+        public int Distance;
+        public float[][] Drops;
+        public LootDrop[] Loot;
+    }
+
+    [Serializable]
     public class LootTable
     {
         public string Object;
@@ -31,6 +39,7 @@ namespace EpicLoot
         public LootDrop[] Loot2;
         public LootDrop[] Loot3;
         public List<LeveledLootDef> LeveledLoot = new List<LeveledLootDef>();
+        public List<DistanceLootDef> DistanceLoot = new List<DistanceLootDef>();
     }
 
     [Serializable]

--- a/EpicLoot/LootRoller.cs
+++ b/EpicLoot/LootRoller.cs
@@ -693,6 +693,23 @@ namespace EpicLoot
 
         public static List<KeyValuePair<int, float>> GetDropsForLevelOrDistance([NotNull] LootTable lootTable, int level, int distance, bool useNextHighestIfNotPresent = true)
         {
+            if (lootTable.DistanceLoot.Count > 0)
+            {
+                var drops = lootTable.Drops;
+
+                int maxDistanceUsed = -1;
+                foreach (var distanceLoot in lootTable.DistanceLoot)
+                {
+                    if (distance >= distanceLoot.Distance && distanceLoot.Distance > maxDistanceUsed)
+                    {
+                        drops = distanceLoot.Drops;
+                        maxDistanceUsed = distanceLoot.Distance;
+                    }
+                }
+
+                return ToDropList(drops);
+            }
+
             if (level == 3 && !ArrayUtils.IsNullOrEmpty(lootTable.Drops3))
             {
                 if (lootTable.LeveledLoot.Any(x => x.Level == level))
@@ -717,23 +734,6 @@ namespace EpicLoot
                 {
                     EpicLoot.LogWarning($"Duplicated leveled drops for ({lootTable.Object} lvl {level}), using 'Drops'");
                 }
-                return ToDropList(lootTable.Drops);
-            }
-
-            if(lootTable.DistanceLoot.Count > 0)
-            {
-                var drops = lootTable.Drops;
-
-                int maxDistanceUsed = -1;
-                foreach (var distanceLoot in lootTable.DistanceLoot)
-                {
-                    if(distance >= distanceLoot.Distance && distanceLoot.Distance > maxDistanceUsed)
-                    {
-                        drops = distanceLoot.Drops;
-                        maxDistanceUsed = distanceLoot.Distance;
-                    }
-                }
-
                 return ToDropList(lootTable.Drops);
             }
 
@@ -762,6 +762,23 @@ namespace EpicLoot
 
         public static LootDrop[] GetLootForLevelOrDistance([NotNull] LootTable lootTable, int level, int distance, bool useNextHighestIfNotPresent = true)
         {
+            if (lootTable.DistanceLoot.Count > 0)
+            {
+                var loot = lootTable.Loot;
+
+                int maxDistanceUsed = -1;
+                foreach (var distanceLoot in lootTable.DistanceLoot)
+                {
+                    if (distance >= distanceLoot.Distance && distanceLoot.Distance > maxDistanceUsed)
+                    {
+                        loot = distanceLoot.Loot;
+                        maxDistanceUsed = distanceLoot.Distance;
+                    }
+                }
+
+                return loot.ToArray();
+            }
+
             if (level == 3 && !ArrayUtils.IsNullOrEmpty(lootTable.Loot3))
             {
                 if (lootTable.LeveledLoot.Any(x => x.Level == level))
@@ -787,23 +804,6 @@ namespace EpicLoot
                     EpicLoot.LogWarning($"Duplicated leveled loot for ({lootTable.Object} lvl {level}), using 'Loot'");
                 }
                 return lootTable.Loot.ToArray();
-            }
-
-            if (lootTable.DistanceLoot.Count > 0)
-            {
-                var loot = lootTable.Loot;
-
-                int maxDistanceUsed = -1;
-                foreach (var distanceLoot in lootTable.DistanceLoot)
-                {
-                    if (distance >= distanceLoot.Distance && distanceLoot.Distance > maxDistanceUsed)
-                    {
-                        loot = distanceLoot.Loot;
-                        maxDistanceUsed = distanceLoot.Distance;
-                    }
-                }
-
-                return loot.ToArray();
             }
 
             for (var lvl = level; lvl >= 1; --lvl)

--- a/EpicLoot/Terminal_Patch.cs
+++ b/EpicLoot/Terminal_Patch.cs
@@ -186,7 +186,8 @@ namespace EpicLoot
                 var lootTable = args.Length > 1 ? args[1] : "Greydwarf";
                 var level = args.Length > 2 ? int.Parse(args[2]) : 1;
                 var itemIndex = args.Length > 3 ? int.Parse(args[3]) : 0;
-                LootRoller.PrintLootResolutionTest(lootTable, level, itemIndex);
+                var distance = args.Length > 4 ? int.Parse(args[4]) : 0;
+                LootRoller.PrintLootResolutionTest(lootTable, level, distance, itemIndex);
             }));
             new Terminal.ConsoleCommand("resetcooldowns", "", (args =>
             {

--- a/EpicLoot/loottables.json
+++ b/EpicLoot/loottables.json
@@ -1456,6 +1456,16 @@
       "Loot": [
         { "Item": "Tier0Everything", "Weight": 4, "Rarity": [ 97, 2, 1, 0] },
         { "Item": "Tier1Everything", "Weight": 1, "Rarity": [ 97, 2, 1, 0] }
+      ],
+      "DistanceLoot": [
+        {
+          "Distance": 4000,
+          "Drops": [ [0, 40], [1, 38], [2, 20], [3, 2] ],
+          "Loot": [
+            { "Item": "Tier0Everything", "Weight": 4, "Rarity": [ 97, 2, 1, 0] },
+            { "Item": "Tier1Everything", "Weight": 1, "Rarity": [ 97, 2, 1, 0] }
+          ]
+        }
       ]
     },
     //TreasureChest_blackforest


### PR DESCRIPTION
Motivation: it's good to add the possibility to adjust chests loot so the further they are located in the world (especially when corresponding CreatureLevelControl setting for mob stars chances based on the distance from the world center is being used) the more loot player gets from them.

Backward compatibility: full