### PR TITLE
Implemented loot filter

### DIFF
--- a/EpicLoot/Crafting/AugmentChoiceDialog.cs
+++ b/EpicLoot/Crafting/AugmentChoiceDialog.cs
@@ -137,7 +137,7 @@ namespace EpicLoot.Crafting
                 var button = EffectChoiceButtons[index];
                 button.gameObject.SetActive(true);
                 var text = button.GetComponentInChildren<TMP_Text>();
-                text.text = Localization.instance.Localize((index == 0 ? "<color=white>($mod_epicloot_augment_keep)</color> " : "") + MagicItem.GetEffectText(effect, rarity, fromItem.m_shared.m_name, true, magicItem.LegendaryID));
+                text.text = Localization.instance.Localize((index == 0 ? "<color=white>($mod_epicloot_augment_keep)</color> " : "") + MagicItem.GetEffectText(effect, rarity, magicItem.Quality, fromItem.m_shared.m_name, true, magicItem.LegendaryID));
                 text.color = rarityColor;
 
                 if (EpicLoot.HasAuga)

--- a/EpicLoot/Crafting/AugmentChoiceDialog.cs
+++ b/EpicLoot/Crafting/AugmentChoiceDialog.cs
@@ -137,7 +137,7 @@ namespace EpicLoot.Crafting
                 var button = EffectChoiceButtons[index];
                 button.gameObject.SetActive(true);
                 var text = button.GetComponentInChildren<TMP_Text>();
-                text.text = Localization.instance.Localize((index == 0 ? "<color=white>($mod_epicloot_augment_keep)</color> " : "") + MagicItem.GetEffectText(effect, rarity, fromItem.m_shared.m_name, true));
+                text.text = Localization.instance.Localize((index == 0 ? "<color=white>($mod_epicloot_augment_keep)</color> " : "") + MagicItem.GetEffectText(effect, rarity, fromItem.m_shared.m_name, true, magicItem.LegendaryID));
                 text.color = rarityColor;
 
                 if (EpicLoot.HasAuga)

--- a/EpicLoot/Crafting/AugmentChoiceDialog.cs
+++ b/EpicLoot/Crafting/AugmentChoiceDialog.cs
@@ -137,7 +137,7 @@ namespace EpicLoot.Crafting
                 var button = EffectChoiceButtons[index];
                 button.gameObject.SetActive(true);
                 var text = button.GetComponentInChildren<TMP_Text>();
-                text.text = Localization.instance.Localize((index == 0 ? "<color=white>($mod_epicloot_augment_keep)</color> " : "") + MagicItem.GetEffectText(effect, rarity, true));
+                text.text = Localization.instance.Localize((index == 0 ? "<color=white>($mod_epicloot_augment_keep)</color> " : "") + MagicItem.GetEffectText(effect, rarity, fromItem.m_shared.m_name, true));
                 text.color = rarityColor;
 
                 if (EpicLoot.HasAuga)

--- a/EpicLoot/Crafting/AugmentHelper.cs
+++ b/EpicLoot/Crafting/AugmentHelper.cs
@@ -169,7 +169,7 @@ namespace EpicLoot.Crafting
             if (recipe.EffectIndex >= 0 && recipe.EffectIndex < magicItem.Effects.Count)
             {
                 var currentEffectDef = MagicItemEffectDefinitions.Get(magicItem.Effects[recipe.EffectIndex].EffectType);
-                valuelessEffect = currentEffectDef.GetValuesForRarity(rarity, item.m_shared.m_name) == null;
+                valuelessEffect = currentEffectDef.GetValuesForRarity(rarity, item.m_shared.m_name, magicItem.Quality) == null;
             }
 
             return MagicItemEffectDefinitions.GetAvailableEffects(item.Extended(), item.GetMagicItem(), valuelessEffect ? -1 : recipe.EffectIndex);
@@ -179,7 +179,7 @@ namespace EpicLoot.Crafting
         {
             var pip = EpicLoot.GetMagicEffectPip(magicItem.IsEffectAugmented(i));
             bool free = EnchantCostsHelper.EffectIsDeprecated(augmentableEffects[i].EffectType);
-            return $"{pip} {Localization.instance.Localize(MagicItem.GetEffectText(augmentableEffects[i], rarity, magicItem.ItemName, true, magicItem.LegendaryID))}{(free ? " [<color=yellow>*FREE</color>]" : "")}";
+            return $"{pip} {Localization.instance.Localize(MagicItem.GetEffectText(augmentableEffects[i], rarity, magicItem.Quality, magicItem.ItemName, true, magicItem.LegendaryID))}{(free ? " [<color=yellow>*FREE</color>]" : "")}";
         }
 
         public static List<KeyValuePair<ItemDrop, int>> GetAugmentCosts(ItemDrop.ItemData item, int recipeEffectIndex)

--- a/EpicLoot/Crafting/AugmentHelper.cs
+++ b/EpicLoot/Crafting/AugmentHelper.cs
@@ -169,7 +169,7 @@ namespace EpicLoot.Crafting
             if (recipe.EffectIndex >= 0 && recipe.EffectIndex < magicItem.Effects.Count)
             {
                 var currentEffectDef = MagicItemEffectDefinitions.Get(magicItem.Effects[recipe.EffectIndex].EffectType);
-                valuelessEffect = currentEffectDef.GetValuesForRarity(rarity) == null;
+                valuelessEffect = currentEffectDef.GetValuesForRarity(rarity, item.m_shared.m_name) == null;
             }
 
             return MagicItemEffectDefinitions.GetAvailableEffects(item.Extended(), item.GetMagicItem(), valuelessEffect ? -1 : recipe.EffectIndex);
@@ -179,7 +179,7 @@ namespace EpicLoot.Crafting
         {
             var pip = EpicLoot.GetMagicEffectPip(magicItem.IsEffectAugmented(i));
             bool free = EnchantCostsHelper.EffectIsDeprecated(augmentableEffects[i].EffectType);
-            return $"{pip} {Localization.instance.Localize(MagicItem.GetEffectText(augmentableEffects[i], rarity, true))}{(free ? " [<color=yellow>*FREE</color>]" : "")}";
+            return $"{pip} {Localization.instance.Localize(MagicItem.GetEffectText(augmentableEffects[i], rarity, magicItem.ItemName, true))}{(free ? " [<color=yellow>*FREE</color>]" : "")}";
         }
 
         public static List<KeyValuePair<ItemDrop, int>> GetAugmentCosts(ItemDrop.ItemData item, int recipeEffectIndex)

--- a/EpicLoot/Crafting/AugmentHelper.cs
+++ b/EpicLoot/Crafting/AugmentHelper.cs
@@ -179,7 +179,7 @@ namespace EpicLoot.Crafting
         {
             var pip = EpicLoot.GetMagicEffectPip(magicItem.IsEffectAugmented(i));
             bool free = EnchantCostsHelper.EffectIsDeprecated(augmentableEffects[i].EffectType);
-            return $"{pip} {Localization.instance.Localize(MagicItem.GetEffectText(augmentableEffects[i], rarity, magicItem.ItemName, true))}{(free ? " [<color=yellow>*FREE</color>]" : "")}";
+            return $"{pip} {Localization.instance.Localize(MagicItem.GetEffectText(augmentableEffects[i], rarity, magicItem.ItemName, true, magicItem.LegendaryID))}{(free ? " [<color=yellow>*FREE</color>]" : "")}";
         }
 
         public static List<KeyValuePair<ItemDrop, int>> GetAugmentCosts(ItemDrop.ItemData item, int recipeEffectIndex)

--- a/EpicLoot/Crafting/AugmentsAvailableDialog.cs
+++ b/EpicLoot/Crafting/AugmentsAvailableDialog.cs
@@ -72,7 +72,7 @@ namespace EpicLoot.Crafting
 
                 foreach (var effectDef in availableEffects)
                 {
-                    var values = effectDef.GetValuesForRarity(item.GetRarity());
+                    var values = effectDef.GetValuesForRarity(item.GetRarity(), item.m_shared.m_name);
                     var valueDisplay = values != null ? Mathf.Approximately(values.MinValue, values.MaxValue) ? $"{values.MinValue}" : $"({values.MinValue}-{values.MaxValue})" : "";
                     t.AppendLine($"‣ {string.Format(Localization.instance.Localize(effectDef.DisplayText), valueDisplay)}");
                 }

--- a/EpicLoot/Crafting/AugmentsAvailableDialog.cs
+++ b/EpicLoot/Crafting/AugmentsAvailableDialog.cs
@@ -72,7 +72,7 @@ namespace EpicLoot.Crafting
 
                 foreach (var effectDef in availableEffects)
                 {
-                    var values = effectDef.GetValuesForRarity(item.GetRarity(), item.m_shared.m_name);
+                    var values = effectDef.GetValuesForRarity(item.GetRarity(), item.m_shared.m_name, magicItem.Quality);
                     var valueDisplay = values != null ? Mathf.Approximately(values.MinValue, values.MaxValue) ? $"{values.MinValue}" : $"({values.MinValue}-{values.MaxValue})" : "";
                     t.AppendLine($"‣ {string.Format(Localization.instance.Localize(effectDef.DisplayText), valueDisplay)}");
                 }

--- a/EpicLoot/CraftingV2/EnchantingUIController.cs
+++ b/EpicLoot/CraftingV2/EnchantingUIController.cs
@@ -388,7 +388,7 @@ namespace EpicLoot.CraftingV2
             
             foreach (var effectDef in availableEffects)
             {
-                var values = effectDef.GetValuesForRarity(rarity);
+                var values = effectDef.GetValuesForRarity(rarity, item.m_shared.m_name);
                 var valueDisplay = values != null ? Mathf.Approximately(values.MinValue, values.MaxValue) ? $"{values.MinValue}" : $"({values.MinValue}-{values.MaxValue})" : "";
                 sb.AppendLine($"‣ {string.Format(Localization.instance.Localize(effectDef.DisplayText), valueDisplay)}");
             }
@@ -520,7 +520,7 @@ namespace EpicLoot.CraftingV2
             if (augmentindex >= 0 && augmentindex < magicItem.Effects.Count)
             {
                 var currentEffectDef = MagicItemEffectDefinitions.Get(magicItem.Effects[augmentindex].EffectType);
-                valuelessEffect = currentEffectDef.GetValuesForRarity(rarity) == null;
+                valuelessEffect = currentEffectDef.GetValuesForRarity(rarity, item.m_shared.m_name) == null;
             }
 
             var availableEffects = MagicItemEffectDefinitions.GetAvailableEffects(item.Extended(), item.GetMagicItem(), valuelessEffect ? -1 : augmentindex);
@@ -529,7 +529,7 @@ namespace EpicLoot.CraftingV2
             sb.Append($"<color={rarityColor}>");
             foreach (var effectDef in availableEffects)
             {
-                var values = effectDef.GetValuesForRarity(item.GetRarity());
+                var values = effectDef.GetValuesForRarity(item.GetRarity(), item.m_shared.m_name);
                 var valueDisplay = values != null ? Mathf.Approximately(values.MinValue, values.MaxValue) ? $"{values.MinValue}" : $"({values.MinValue}-{values.MaxValue})" : "";
                 sb.AppendLine($"‣ {string.Format(Localization.instance.Localize(effectDef.DisplayText), valueDisplay)}");
             }

--- a/EpicLoot/CraftingV2/EnchantingUIController.cs
+++ b/EpicLoot/CraftingV2/EnchantingUIController.cs
@@ -388,7 +388,7 @@ namespace EpicLoot.CraftingV2
             
             foreach (var effectDef in availableEffects)
             {
-                var values = effectDef.GetValuesForRarity(rarity, item.m_shared.m_name);
+                var values = effectDef.GetValuesForRarity(rarity, item.m_shared.m_name, ItemQuality.Normal);
                 var valueDisplay = values != null ? Mathf.Approximately(values.MinValue, values.MaxValue) ? $"{values.MinValue}" : $"({values.MinValue}-{values.MaxValue})" : "";
                 sb.AppendLine($"‣ {string.Format(Localization.instance.Localize(effectDef.DisplayText), valueDisplay)}");
             }
@@ -418,7 +418,7 @@ namespace EpicLoot.CraftingV2
                 previousDurabilityPercent = item.m_durability / item.GetMaxDurability();
 
             var luckFactor = player.GetTotalActiveMagicEffectValue(MagicEffectType.Luck, 0.01f);
-            var magicItem = LootRoller.RollMagicItem((ItemRarity)rarity, item, luckFactor);
+            var magicItem = LootRoller.RollMagicItem((ItemRarity)rarity, ItemQuality.Normal, item, luckFactor);
 
             var magicItemComponent = item.Data().GetOrCreate<MagicItemComponent>();
             magicItemComponent.SetMagicItem(magicItem);
@@ -520,7 +520,7 @@ namespace EpicLoot.CraftingV2
             if (augmentindex >= 0 && augmentindex < magicItem.Effects.Count)
             {
                 var currentEffectDef = MagicItemEffectDefinitions.Get(magicItem.Effects[augmentindex].EffectType);
-                valuelessEffect = currentEffectDef.GetValuesForRarity(rarity, item.m_shared.m_name) == null;
+                valuelessEffect = currentEffectDef.GetValuesForRarity(rarity, item.m_shared.m_name, magicItem.Quality) == null;
             }
 
             var availableEffects = MagicItemEffectDefinitions.GetAvailableEffects(item.Extended(), item.GetMagicItem(), valuelessEffect ? -1 : augmentindex);
@@ -529,7 +529,7 @@ namespace EpicLoot.CraftingV2
             sb.Append($"<color={rarityColor}>");
             foreach (var effectDef in availableEffects)
             {
-                var values = effectDef.GetValuesForRarity(item.GetRarity(), item.m_shared.m_name);
+                var values = effectDef.GetValuesForRarity(item.GetRarity(), item.m_shared.m_name, magicItem.Quality);
                 var valueDisplay = values != null ? Mathf.Approximately(values.MinValue, values.MaxValue) ? $"{values.MinValue}" : $"({values.MinValue}-{values.MaxValue})" : "";
                 sb.AppendLine($"‣ {string.Format(Localization.instance.Localize(effectDef.DisplayText), valueDisplay)}");
             }

--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -1483,7 +1483,7 @@ namespace EpicLoot
             for (var i = 0; i < limit; i++)
             {
                 var level = i + 1;
-                var dropTable = LootRoller.GetDropsForLevel(lootTable, level, false);
+                var dropTable = LootRoller.GetDropsForLevelOrDistance(lootTable, level, 0, false);
                 if (dropTable == null || dropTable.Count == 0)
                 {
                     continue;
@@ -1513,7 +1513,7 @@ namespace EpicLoot
             for (var i = 0; i < limit; i++)
             {
                 var level = i + 1;
-                var lootList = LootRoller.GetLootForLevel(lootTable, level, false);
+                var lootList = LootRoller.GetLootForLevelOrDistance(lootTable, level, 0, false);
                 if (ArrayUtils.IsNullOrEmpty(lootList))
                 {
                     continue;

--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -119,6 +119,7 @@ namespace EpicLoot
         public static ConfigEntry<bool> UseScrollingCraftDescription;
         public static ConfigEntry<bool> TransferMagicItemToCrafts;
         public static ConfigEntry<EffectValueRollDistributionTypes> EffectValueRollDistribution;
+        public static ConfigEntry<bool> UseLootFilters;
         public static ConfigEntry<CraftingTabStyle> CraftingTabStyle;
         private static ConfigEntry<bool> _loggingEnabled;
         private static ConfigEntry<LogLevel> _logLevel;
@@ -243,6 +244,7 @@ namespace EpicLoot
             ItemsToMaterialsDropRatio = SyncedConfig("Balance", "Items To Materials Drop Ratio", 0.0f, "Sets the chance that item drops are instead dropped as magic crafting materials. 0 = all items, no materials. 1 = all materials, no items. Values between 0 and 1 change the ratio of items to materials that drop. At 0.5, half of everything that drops would be items and the other half would be materials. Min = 0, Max = 1");
             TransferMagicItemToCrafts = SyncedConfig("Balance", "Transfer Enchants to Crafted Items", false, "When enchanted items are used as ingredients in recipes, transfer the highest enchant to the newly crafted item. Default: False.");
             EffectValueRollDistribution = SyncedConfig("Balance", "Effect Value Roll Distribution", EffectValueRollDistributionTypes.Linear, "Function to be used for rolling effect values on an item. Linear: any number in the possible effect value range can be rolled with equal chance. TendsToLowAverage: values close to min and especially max of the range are very unlikely to be rolled. Default: Linear.");
+            UseLootFilters = SyncedConfig("Balance", "Use Loot Filters", false, "If set to true, all item drop will be affected by loot filters (defined in lootfilters.json). Loot filters allow to prevent dropping of the items you don't need anymore or auto sacrifice the unneeded items into materials on drop.");
 
             AlwaysShowWelcomeMessage = Config.Bind("Debug", "AlwaysShowWelcomeMessage", false, "Just a debug flag for testing the welcome message, do not use.");
             OutputPatchedConfigFiles = Config.Bind("Debug", "OutputPatchedConfigFiles", false, "Just a debug flag for testing the patching system, do not use.");
@@ -496,6 +498,7 @@ namespace EpicLoot
             LoadJsonFile<AbilityConfig>("abilities.json", AbilityDefinitions.Initialize, ConfigType.Synced);
             LoadJsonFile<MaterialConversionsConfig>("materialconversions.json", MaterialConversions.Initialize, ConfigType.Synced);
             LoadJsonFile<EnchantingUpgradesConfig>("enchantingupgrades.json", EnchantingTableUpgrades.InitializeConfig, ConfigType.Synced);
+            LoadJsonFile<LootFiltersConfig>("lootfilters.json", LootFilterDefinitions.Initialize, ConfigType.Synced);
 
             WatchNewPatchConfig();
         }

--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -52,6 +52,12 @@ namespace EpicLoot
         BossKillUnlocksNextBiomeBounties
     }
 
+    public enum EffectValueRollDistributionTypes
+    {
+        Linear,
+        TendsToLowAverage
+    }
+
     public class Assets
     {
         public AssetBundle AssetBundle;
@@ -112,6 +118,7 @@ namespace EpicLoot
         //private static ConfigEntry<int> _mythicMaterialIconColor;
         public static ConfigEntry<bool> UseScrollingCraftDescription;
         public static ConfigEntry<bool> TransferMagicItemToCrafts;
+        public static ConfigEntry<EffectValueRollDistributionTypes> EffectValueRollDistribution;
         public static ConfigEntry<CraftingTabStyle> CraftingTabStyle;
         private static ConfigEntry<bool> _loggingEnabled;
         private static ConfigEntry<LogLevel> _logLevel;
@@ -235,6 +242,7 @@ namespace EpicLoot
             GlobalDropRateModifier = SyncedConfig("Balance", "Global Drop Rate Modifier", 1.0f, "A global percentage that modifies how likely items are to drop. 1 = Exactly what is in the loot tables will drop. 0 = Nothing will drop. 2 = The number of items in the drop table are twice as likely to drop (note, this doesn't double the number of items dropped, just doubles the relative chance for them to drop). Min = 0, Max = 4");
             ItemsToMaterialsDropRatio = SyncedConfig("Balance", "Items To Materials Drop Ratio", 0.0f, "Sets the chance that item drops are instead dropped as magic crafting materials. 0 = all items, no materials. 1 = all materials, no items. Values between 0 and 1 change the ratio of items to materials that drop. At 0.5, half of everything that drops would be items and the other half would be materials. Min = 0, Max = 1");
             TransferMagicItemToCrafts = SyncedConfig("Balance", "Transfer Enchants to Crafted Items", false, "When enchanted items are used as ingredients in recipes, transfer the highest enchant to the newly crafted item. Default: False.");
+            EffectValueRollDistribution = SyncedConfig("Balance", "Effect Value Roll Distribution", EffectValueRollDistributionTypes.Linear, "Function to be used for rolling effect values on an item. Linear: any number in the possible effect value range can be rolled with equal chance. TendsToLowAverage: values close to min and especially max of the range are very unlikely to be rolled. Default: Linear.");
 
             AlwaysShowWelcomeMessage = Config.Bind("Debug", "AlwaysShowWelcomeMessage", false, "Just a debug flag for testing the welcome message, do not use.");
             OutputPatchedConfigFiles = Config.Bind("Debug", "OutputPatchedConfigFiles", false, "Just a debug flag for testing the patching system, do not use.");

--- a/EpicLoot/EpicLoot.csproj
+++ b/EpicLoot/EpicLoot.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Adventure\Game_Patch.cs" />
     <Compile Include="Adventure\MinimapController.cs" />
     <Compile Include="Attack_Patch.cs" />
+    <Compile Include="LootFilter.cs" />
     <Compile Include="CraftingV2\EnchantingTable_Patch.cs" />
     <Compile Include="CraftingV2\EnchantingUIAugaFixup.cs" />
     <Compile Include="CraftingV2\EnchantingUIController.cs" />
@@ -287,6 +288,7 @@
     <None Include="translations.json" />
     <None Include="loottables.json" />
     <None Include="magiceffects.json" />
+    <None Include="lootfilters.json" />
     <None Include="manifest.json" />
     <None Include="CHANGELOG.md" />
     <None Include="todo.md" />
@@ -338,6 +340,7 @@
       xcopy "$(ProjectDir)legendaries.json" "G:\Steam\steamapps\common\Valheim-Dev\BepInEx\plugins\$(ProjectName)\" /q /y /i
       xcopy "$(ProjectDir)abilities.json" "G:\Steam\steamapps\common\Valheim-Dev\BepInEx\plugins\$(ProjectName)\" /q /y /i
       xcopy "$(ProjectDir)materialconversions.json" "G:\Steam\steamapps\common\Valheim-Dev\BepInEx\plugins\$(ProjectName)\" /q /y /i
+      xcopy "$(ProjectDir)lootfilter.json" "G:\Steam\steamapps\common\Valheim-Dev\BepInEx\plugins\$(ProjectName)\" /q /y /i
 </PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\ILRepack.Lib.MSBuild.Task.2.0.18.2\build\ILRepack.Lib.MSBuild.Task.targets" Condition="Exists('..\packages\ILRepack.Lib.MSBuild.Task.2.0.18.2\build\ILRepack.Lib.MSBuild.Task.targets')" />

--- a/EpicLoot/LegendarySystem/LegendaryItemConfig.cs
+++ b/EpicLoot/LegendarySystem/LegendaryItemConfig.cs
@@ -28,6 +28,8 @@ namespace EpicLoot.LegendarySystem
         public string Description;
         public MagicItemEffectRequirements Requirements;
         public List<GuaranteedMagicEffect> GuaranteedMagicEffects = new List<GuaranteedMagicEffect>();
+        public List<GuaranteedMagicEffect> GuaranteedMagicEffectsExceptional = new List<GuaranteedMagicEffect>();
+        public List<GuaranteedMagicEffect> GuaranteedMagicEffectsElite = new List<GuaranteedMagicEffect>();
         public int GuaranteedEffectCount = -1;
         public float SelectionWeight = 1;
         public string EquipFx;

--- a/EpicLoot/LegendarySystem/UniqueLegendaryHelper.cs
+++ b/EpicLoot/LegendarySystem/UniqueLegendaryHelper.cs
@@ -69,10 +69,25 @@ namespace EpicLoot.LegendarySystem
             return availableLegendaries;
         }
 
-        public static MagicItemEffectDefinition.ValueDef GetLegendaryEffectValues(string legendaryID, string effectType)
+        public static MagicItemEffectDefinition.ValueDef GetLegendaryEffectValues(string legendaryID, string effectType, ItemQuality quality)
         {
             if (LegendaryInfo.TryGetValue(legendaryID, out var legendaryInfo))
             {
+                if (quality == ItemQuality.Elite)
+                {
+                    if (legendaryInfo.GuaranteedMagicEffectsElite.TryFind(x => x.Type == effectType, out var guaranteedMagicEffectElite))
+                    {
+                        return guaranteedMagicEffectElite.Values;
+                    }
+                }
+                else if (quality == ItemQuality.Exceptional)
+                {
+                    if (legendaryInfo.GuaranteedMagicEffectsExceptional.TryFind(x => x.Type == effectType, out var guaranteedMagicEffectExceptional))
+                    {
+                        return guaranteedMagicEffectExceptional.Values;
+                    }
+                }
+
                 if (legendaryInfo.GuaranteedMagicEffects.TryFind(x => x.Type == effectType, out var guaranteedMagicEffect))
                 {
                     return guaranteedMagicEffect.Values;

--- a/EpicLoot/LegendarySystem/UniqueLegendaryHelper.cs
+++ b/EpicLoot/LegendarySystem/UniqueLegendaryHelper.cs
@@ -75,14 +75,14 @@ namespace EpicLoot.LegendarySystem
             {
                 if (quality == ItemQuality.Elite)
                 {
-                    if (legendaryInfo.GuaranteedMagicEffectsElite.TryFind(x => x.Type == effectType, out var guaranteedMagicEffectElite))
+                    if (legendaryInfo.GuaranteedMagicEffectsElite.Count() > 0 && legendaryInfo.GuaranteedMagicEffectsElite.TryFind(x => x.Type == effectType, out var guaranteedMagicEffectElite))
                     {
                         return guaranteedMagicEffectElite.Values;
                     }
                 }
                 else if (quality == ItemQuality.Exceptional)
                 {
-                    if (legendaryInfo.GuaranteedMagicEffectsExceptional.TryFind(x => x.Type == effectType, out var guaranteedMagicEffectExceptional))
+                    if (legendaryInfo.GuaranteedMagicEffectsExceptional.Count() > 0 && legendaryInfo.GuaranteedMagicEffectsExceptional.TryFind(x => x.Type == effectType, out var guaranteedMagicEffectExceptional))
                     {
                         return guaranteedMagicEffectExceptional.Values;
                     }

--- a/EpicLoot/LootConfig.cs
+++ b/EpicLoot/LootConfig.cs
@@ -9,6 +9,7 @@ namespace EpicLoot
         public string Item;
         public float Weight = 1;
         public float[] Rarity;
+        public float[] Quality;
     }
 
     [Serializable]

--- a/EpicLoot/LootConfig.cs
+++ b/EpicLoot/LootConfig.cs
@@ -20,6 +20,14 @@ namespace EpicLoot
     }
 
     [Serializable]
+    public class DistanceLootDef
+    {
+        public int Distance;
+        public float[][] Drops;
+        public LootDrop[] Loot;
+    }
+
+    [Serializable]
     public class LootTable
     {
         public string Object;
@@ -31,6 +39,7 @@ namespace EpicLoot
         public LootDrop[] Loot2;
         public LootDrop[] Loot3;
         public List<LeveledLootDef> LeveledLoot = new List<LeveledLootDef>();
+        public List<DistanceLootDef> DistanceLoot = new List<DistanceLootDef>();
     }
 
     [Serializable]

--- a/EpicLoot/LootFilter.cs
+++ b/EpicLoot/LootFilter.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EpicLoot
+{
+    [Serializable]
+    public class LootFilter
+    {
+        public string Name;
+        public bool Whitelist; 
+        public bool DropMaterials;
+        public List<string> Items = new List<string>();
+        public List<ItemRarity> Rarities = new List<ItemRarity>();
+        public List<ItemQuality> Quality = new List<ItemQuality>();
+        public int Distance;
+        // public int Day; to be implemented for full accordance with CreatureLevelControl world level settings, that is, distance or day based
+    }
+
+    [Serializable]
+    public class LootFiltersConfig
+    {
+        public List<LootFilter> LootFilters = new List<LootFilter>();
+    }
+
+    public class LootFilterDefinitions {
+        public static readonly List<LootFilter> BlackLists = new List<LootFilter>();
+        public static readonly List<LootFilter> WhiteLists = new List<LootFilter>();
+
+        public static void Initialize(LootFiltersConfig _config)
+        {
+            foreach(var item in _config?.LootFilters)
+            {
+                if(item.Whitelist)
+                {
+                    WhiteLists.Add(item);
+                }
+                else
+                {
+                    BlackLists.Add(item);
+                }
+            }
+        }
+
+        public static bool FilteredOut(string itemName, ItemRarity rarity, ItemQuality quality, int distance, out bool dropMaterials)
+        {
+            bool ItemMatches(LootFilter item, out bool dropMats)
+            {
+                dropMats = item.DropMaterials;
+                return item.Items.Contains(itemName) && item.Rarities.Contains(rarity) && item.Quality.Contains(quality) && distance > item.Distance;
+            }
+
+            foreach (var item in WhiteLists)
+            {
+                if(ItemMatches(item, out dropMaterials))
+                {
+                    return false;
+                }
+            }
+
+            foreach (var item in BlackLists)
+            {
+                if (ItemMatches(item, out dropMaterials))
+                {
+                    return true;
+                }
+            }
+
+            dropMaterials = false;
+            return false;
+        }
+    }
+}

--- a/EpicLoot/LootFilter.cs
+++ b/EpicLoot/LootFilter.cs
@@ -49,7 +49,7 @@ namespace EpicLoot
             bool ItemMatches(LootFilter item, out bool dropMats)
             {
                 dropMats = item.DropMaterials;
-                return item.Items.Contains(itemName) && item.Rarities.Contains(rarity) && item.Quality.Contains(quality) && distance > item.Distance;
+                return item.Items.Contains(itemName) && item.Rarities.Contains(rarity) && item.Quality.Contains(quality) && distance >= item.Distance;
             }
 
             foreach (var item in WhiteLists)

--- a/EpicLoot/LootRoller.cs
+++ b/EpicLoot/LootRoller.cs
@@ -351,7 +351,7 @@ namespace EpicLoot
                     var magicItem = RollMagicItem(lootDrop, itemData, luckFactor);
                     if (CheatForceMagicEffect)
                     {
-                        AddDebugMagicEffects(magicItem);
+                        AddDebugMagicEffects(magicItem, itemData.m_shared.m_name);
                     }
                     magicItemComponent.SetMagicItem(magicItem);
                     itemDrop.m_itemData = itemData;
@@ -464,7 +464,7 @@ namespace EpicLoot
                 rarity = ItemRarity.Legendary;
             }
 
-            var magicItem = new MagicItem { Rarity = rarity };
+            var magicItem = new MagicItem { Rarity = rarity, ItemName = baseItem.m_shared.m_name };
 
             var effectCount = CheatEffectCount >= 1 ? CheatEffectCount : RollEffectCountPerRarity(magicItem.Rarity);
 
@@ -512,7 +512,7 @@ namespace EpicLoot
                             continue;
                         }
 
-                        var effect = RollEffect(effectDef, ItemRarity.Legendary, guaranteedMagicEffect.Values);
+                        var effect = RollEffect(effectDef, ItemRarity.Legendary, baseItem.m_shared.m_name, guaranteedMagicEffect.Values);
                         magicItem.Effects.Add(effect);
                         effectCount--;
                     }
@@ -532,7 +532,7 @@ namespace EpicLoot
                 _weightedEffectTable.Setup(availableEffects, x => x.SelectionWeight);
                 var effectDef = _weightedEffectTable.Roll();
 
-                var effect = RollEffect(effectDef, magicItem.Rarity);
+                var effect = RollEffect(effectDef, magicItem.Rarity, baseItem.m_shared.m_name);
                 magicItem.Effects.Add(effect);
             }
 
@@ -612,10 +612,10 @@ namespace EpicLoot
             return result;
         }
 
-        public static MagicItemEffect RollEffect(MagicItemEffectDefinition effectDef, ItemRarity itemRarity, MagicItemEffectDefinition.ValueDef valuesOverride = null)
+        public static MagicItemEffect RollEffect(MagicItemEffectDefinition effectDef, ItemRarity itemRarity, string itemName, MagicItemEffectDefinition.ValueDef valuesOverride = null)
         {
             float value = MagicItemEffect.DefaultValue;
-            var valuesDef = valuesOverride ?? effectDef.GetValuesForRarity(itemRarity);
+            var valuesDef = valuesOverride ?? effectDef.GetValuesForRarity(itemRarity, itemName);
             if (valuesDef != null)
             {
                 value = valuesDef.MinValue;
@@ -630,7 +630,8 @@ namespace EpicLoot
             return new MagicItemEffect(effectDef.Type, value);
         }
 
-        public static List<MagicItemEffect> RollEffects(List<MagicItemEffectDefinition> availableEffects, ItemRarity itemRarity, int count, bool removeOnSelect = true)
+
+        public static List<MagicItemEffect> RollEffects(List<MagicItemEffectDefinition> availableEffects, ItemRarity itemRarity, string itemName, int count, bool removeOnSelect = true)
         {
             var results = new List<MagicItemEffect>();
 
@@ -644,7 +645,7 @@ namespace EpicLoot
                     EpicLoot.LogError($"EffectDef was null! RollEffects({itemRarity}, {count})");
                     continue;
                 }
-                results.Add(RollEffect(effectDef, itemRarity));
+                results.Add(RollEffect(effectDef, itemRarity, itemName));
             }
 
             return results;
@@ -818,7 +819,7 @@ namespace EpicLoot
 
             for (var i = 0; i < augmentChoices && i < availableEffects.Count; i++)
             {
-                var newEffect = RollEffects(availableEffects, rarity, 1, false).FirstOrDefault();
+                var newEffect = RollEffects(availableEffects, rarity, item.m_shared.m_name, 1, false).FirstOrDefault();
                 if (newEffect == null)
                 {
                     EpicLoot.LogError($"Rolled a null effect: item:{item.m_shared.m_name}, index:{effectIndex}");
@@ -837,12 +838,12 @@ namespace EpicLoot
             return results;
         }
 
-        public static void AddDebugMagicEffects(MagicItem item)
+        public static void AddDebugMagicEffects(MagicItem item, string itemName)
         {
             if (!string.IsNullOrEmpty(ForcedMagicEffect) && !item.HasEffect(ForcedMagicEffect))
             {
                 EpicLoot.Log($"AddDebugMagicEffect {ForcedMagicEffect}");
-                item.Effects.Add(RollEffect(MagicItemEffectDefinitions.Get(ForcedMagicEffect), item.Rarity));
+                item.Effects.Add(RollEffect(MagicItemEffectDefinitions.Get(ForcedMagicEffect), item.Rarity, itemName));
             }
         }
 

--- a/EpicLoot/LootRoller.cs
+++ b/EpicLoot/LootRoller.cs
@@ -22,6 +22,7 @@ namespace EpicLoot
         public static readonly Dictionary<string, LootItemSet> ItemSets = new Dictionary<string, LootItemSet>();
         public static readonly Dictionary<string, List<LootTable>> LootTables = new Dictionary<string, List<LootTable>>();
 
+        private static System.Random _random; 
         private static WeightedRandomCollection<KeyValuePair<int, float>> _weightedDropCountTable;
         private static WeightedRandomCollection<LootDrop> _weightedLootTable;
         private static WeightedRandomCollection<MagicItemEffectDefinition> _weightedEffectTable;
@@ -39,13 +40,13 @@ namespace EpicLoot
         {
             Config = lootConfig;
             
-            var random = new System.Random();
-            _weightedDropCountTable = new WeightedRandomCollection<KeyValuePair<int, float>>(random);
-            _weightedLootTable = new WeightedRandomCollection<LootDrop>(random);
-            _weightedEffectTable = new WeightedRandomCollection<MagicItemEffectDefinition>(random);
-            _weightedEffectCountTable = new WeightedRandomCollection<KeyValuePair<int, float>>(random);
-            _weightedRarityTable = new WeightedRandomCollection<KeyValuePair<ItemRarity, float>>(random);
-            _weightedLegendaryTable = new WeightedRandomCollection<LegendaryInfo>(random);
+            _random = new System.Random();
+            _weightedDropCountTable = new WeightedRandomCollection<KeyValuePair<int, float>>(_random);
+            _weightedLootTable = new WeightedRandomCollection<LootDrop>(_random);
+            _weightedEffectTable = new WeightedRandomCollection<MagicItemEffectDefinition>(_random);
+            _weightedEffectCountTable = new WeightedRandomCollection<KeyValuePair<int, float>>(_random);
+            _weightedRarityTable = new WeightedRandomCollection<KeyValuePair<ItemRarity, float>>(_random);
+            _weightedLegendaryTable = new WeightedRandomCollection<LegendaryInfo>(_random);
 
             ItemSets.Clear();
             LootTables.Clear();
@@ -623,7 +624,18 @@ namespace EpicLoot
                 {
                     EpicLoot.Log($"RollEffect: {effectDef.Type} {itemRarity} value={value} (min={valuesDef.MinValue} max={valuesDef.MaxValue})");
                     var incrementCount = (int)((valuesDef.MaxValue - valuesDef.MinValue) / valuesDef.Increment);
-                    value = valuesDef.MinValue + (Random.Range(0, incrementCount + 1) * valuesDef.Increment);
+
+                    double v;
+                    if (EpicLoot.EffectValueRollDistribution.Value == EffectValueRollDistributionTypes.TendsToLowAverage)
+                    {
+                        v = Math.Pow(_random.NextDouble() * _random.NextDouble(), 0.7);
+                    }
+                    else
+                    {
+                        v = _random.NextDouble();
+                    }
+
+                    value = valuesDef.MinValue + (int)(v * (incrementCount + 1)) * valuesDef.Increment;
                 }
             }
 

--- a/EpicLoot/LootRoller.cs
+++ b/EpicLoot/LootRoller.cs
@@ -270,60 +270,72 @@ namespace EpicLoot
                 var itemName = !string.IsNullOrEmpty(lootDrop?.Item) ? lootDrop.Item : "Invalid Item Name";
                 var rarityLength = lootDrop?.Rarity?.Length != null ? lootDrop.Rarity.Length : -1;
                 EpicLoot.Log($"Item: {itemName} - Rarity Count: {rarityLength} - Weight: {lootDrop.Weight}");
-                
-                if (!cheatsActive && EpicLoot.ItemsToMaterialsDropRatio.Value > 0)
+
+                var itemID = (CheatDisableGating) ? lootDrop.Item : GatedItemTypeHelper.GetGatedItemID(lootDrop.Item);
+
+                bool ReplaceWithMats()
                 {
-                    var clampedConvertRate = Mathf.Clamp(EpicLoot.ItemsToMaterialsDropRatio.Value, 0.0f, 1.0f);
-                    var replaceWithMats = Random.Range(0.0f, 1.0f) < clampedConvertRate;
-                    if (replaceWithMats)
+                    if (itemID == null)
                     {
-                        GameObject prefab = null;
+                        return true;
+                    }
 
-                        try
-                        {
-                            prefab = ObjectDB.instance.GetItemPrefab(lootDrop.Item);
-                        }
-                        catch (Exception e)
-                        {
-                            EpicLoot.LogWarning($"Unable to get Prefab for [{lootDrop.Item}]. Continuing.");
-                            EpicLoot.LogWarning($"Error: {e.Message}");
-                        }
+                    if (!cheatsActive && EpicLoot.ItemsToMaterialsDropRatio.Value > 0)
+                    {
+                        var clampedConvertRate = Mathf.Clamp(EpicLoot.ItemsToMaterialsDropRatio.Value, 0.0f, 1.0f);
+                        return Random.Range(0.0f, 1.0f) < clampedConvertRate;
+                    }
 
-                        if (prefab != null)
+                    return false;
+                };
+
+                if (ReplaceWithMats())
+                {
+                    GameObject prefab = null;
+
+                    try
+                    {
+                        prefab = ObjectDB.instance.GetItemPrefab(lootDrop.Item);
+                    }
+                    catch (Exception e)
+                    {
+                        EpicLoot.LogWarning($"Unable to get Prefab for [{lootDrop.Item}]. Continuing.");
+                        EpicLoot.LogWarning($"Error: {e.Message}");
+                    }
+
+                    if (prefab != null)
+                    {
+                        var rarity = RollItemRarity(lootDrop, luckFactor);
+                        var itemType = prefab.GetComponent<ItemDrop>().m_itemData.m_shared.m_itemType;
+                        var disenchantProducts = EnchantCostsHelper.GetSacrificeProducts(true, itemType, rarity);
+                        if (disenchantProducts != null)
                         {
-                            var rarity = RollItemRarity(lootDrop, luckFactor);
-                            var itemType = prefab.GetComponent<ItemDrop>().m_itemData.m_shared.m_itemType;
-                            var disenchantProducts = EnchantCostsHelper.GetSacrificeProducts(true, itemType, rarity);
-                            if (disenchantProducts != null)
+                            foreach (var itemAmountConfig in disenchantProducts)
                             {
-                                foreach (var itemAmountConfig in disenchantProducts)
+                                GameObject materialPrefab = null;
+                                try
                                 {
-                                    GameObject materialPrefab = null;
-                                    try
-                                    {
-                                        materialPrefab = ObjectDB.instance.GetItemPrefab(itemAmountConfig.Item);
-                                    }
-                                    catch (Exception e)
-                                    {
-                                        EpicLoot.LogWarning($"Unable to get Disenchant Product Prefab for [{itemAmountConfig?.Item ?? "Invalid Item"}]. Continuing.");
-                                        EpicLoot.LogWarning($"Error: {e.Message}");
-                                    }
-
-                                    if (materialPrefab == null) continue;
-                                    var materialItem = SpawnLootForDrop(materialPrefab, dropPoint, true);
-                                    var materialItemDrop = materialItem.GetComponent<ItemDrop>();
-                                    materialItemDrop.m_itemData.m_stack = itemAmountConfig.Amount;
-                                    if (materialItemDrop.m_itemData.IsMagicCraftingMaterial())
-                                        materialItemDrop.m_itemData.m_variant = EpicLoot.GetRarityIconIndex(rarity);
-                                    results.Add(materialItem);
+                                    materialPrefab = ObjectDB.instance.GetItemPrefab(itemAmountConfig.Item);
                                 }
+                                catch (Exception e)
+                                {
+                                    EpicLoot.LogWarning($"Unable to get Disenchant Product Prefab for [{itemAmountConfig?.Item ?? "Invalid Item"}]. Continuing.");
+                                    EpicLoot.LogWarning($"Error: {e.Message}");
+                                }
+
+                                if (materialPrefab == null) continue;
+                                var materialItem = SpawnLootForDrop(materialPrefab, dropPoint, true);
+                                var materialItemDrop = materialItem.GetComponent<ItemDrop>();
+                                materialItemDrop.m_itemData.m_stack = itemAmountConfig.Amount;
+                                if (materialItemDrop.m_itemData.IsMagicCraftingMaterial())
+                                    materialItemDrop.m_itemData.m_variant = EpicLoot.GetRarityIconIndex(rarity);
+                                results.Add(materialItem);
                             }
                         }
-
-                        continue;
                     }
+
+                    continue;
                 }
-                var itemID = (CheatDisableGating) ? lootDrop.Item : GatedItemTypeHelper.GetGatedItemID(lootDrop.Item);
 
                 GameObject itemPrefab = null;
 

--- a/EpicLoot/LootRoller.cs
+++ b/EpicLoot/LootRoller.cs
@@ -516,11 +516,11 @@ namespace EpicLoot
                     }
 
                     List<GuaranteedMagicEffect> guaranteedMagicEffects;
-                    if (quality == ItemQuality.Elite && legendary.GuaranteedMagicEffectsElite != null)
+                    if (quality == ItemQuality.Elite && legendary.GuaranteedMagicEffectsElite.Count() > 0)
                     {
                         guaranteedMagicEffects = legendary.GuaranteedMagicEffectsElite;
                     }
-                    else if (quality == ItemQuality.Exceptional && legendary.GuaranteedMagicEffectsExceptional != null)
+                    else if (quality == ItemQuality.Exceptional && legendary.GuaranteedMagicEffectsExceptional.Count() > 0)
                     {
                         guaranteedMagicEffects = legendary.GuaranteedMagicEffectsExceptional;
                     }

--- a/EpicLoot/LootRoller.cs
+++ b/EpicLoot/LootRoller.cs
@@ -693,6 +693,23 @@ namespace EpicLoot
 
         public static List<KeyValuePair<int, float>> GetDropsForLevelOrDistance([NotNull] LootTable lootTable, int level, int distance, bool useNextHighestIfNotPresent = true)
         {
+            if (lootTable.DistanceLoot.Count > 0)
+            {
+                var drops = lootTable.Drops;
+
+                int maxDistanceUsed = -1;
+                foreach (var distanceLoot in lootTable.DistanceLoot)
+                {
+                    if (distance >= distanceLoot.Distance && distanceLoot.Distance > maxDistanceUsed)
+                    {
+                        drops = distanceLoot.Drops;
+                        maxDistanceUsed = distanceLoot.Distance;
+                    }
+                }
+
+                return ToDropList(drops);
+            }
+
             if (level == 3 && !ArrayUtils.IsNullOrEmpty(lootTable.Drops3))
             {
                 if (lootTable.LeveledLoot.Any(x => x.Level == level))
@@ -717,23 +734,6 @@ namespace EpicLoot
                 {
                     EpicLoot.LogWarning($"Duplicated leveled drops for ({lootTable.Object} lvl {level}), using 'Drops'");
                 }
-                return ToDropList(lootTable.Drops);
-            }
-
-            if(lootTable.DistanceLoot.Count > 0)
-            {
-                var drops = lootTable.Drops;
-
-                int maxDistanceUsed = -1;
-                foreach (var distanceLoot in lootTable.DistanceLoot)
-                {
-                    if(distance >= distanceLoot.Distance && distanceLoot.Distance > maxDistanceUsed)
-                    {
-                        drops = distanceLoot.Drops;
-                        maxDistanceUsed = distanceLoot.Distance;
-                    }
-                }
-
                 return ToDropList(lootTable.Drops);
             }
 
@@ -762,6 +762,23 @@ namespace EpicLoot
 
         public static LootDrop[] GetLootForLevelOrDistance([NotNull] LootTable lootTable, int level, int distance, bool useNextHighestIfNotPresent = true)
         {
+            if (lootTable.DistanceLoot.Count > 0)
+            {
+                var loot = lootTable.Loot;
+
+                int maxDistanceUsed = -1;
+                foreach (var distanceLoot in lootTable.DistanceLoot)
+                {
+                    if (distance >= distanceLoot.Distance && distanceLoot.Distance > maxDistanceUsed)
+                    {
+                        loot = distanceLoot.Loot;
+                        maxDistanceUsed = distanceLoot.Distance;
+                    }
+                }
+
+                return loot.ToArray();
+            }
+
             if (level == 3 && !ArrayUtils.IsNullOrEmpty(lootTable.Loot3))
             {
                 if (lootTable.LeveledLoot.Any(x => x.Level == level))
@@ -787,23 +804,6 @@ namespace EpicLoot
                     EpicLoot.LogWarning($"Duplicated leveled loot for ({lootTable.Object} lvl {level}), using 'Loot'");
                 }
                 return lootTable.Loot.ToArray();
-            }
-
-            if (lootTable.DistanceLoot.Count > 0)
-            {
-                var loot = lootTable.Loot;
-
-                int maxDistanceUsed = -1;
-                foreach (var distanceLoot in lootTable.DistanceLoot)
-                {
-                    if (distance >= distanceLoot.Distance && distanceLoot.Distance > maxDistanceUsed)
-                    {
-                        loot = distanceLoot.Loot;
-                        maxDistanceUsed = distanceLoot.Distance;
-                    }
-                }
-
-                return loot.ToArray();
             }
 
             for (var lvl = level; lvl >= 1; --lvl)

--- a/EpicLoot/LootRoller.cs
+++ b/EpicLoot/LootRoller.cs
@@ -673,7 +673,16 @@ namespace EpicLoot
                 { ItemRarity.Legendary, rarity.Length >= 4 ? rarity[3] : 0 }
             };
 
-            return ModifyRarityByLuck(rarityWeights, luckFactor);
+            for (var r = ItemRarity.Legendary; r >= ItemRarity.Magic; r--)
+            {
+                if (rarityWeights[r] > 0)
+                {
+                    rarityWeights[r] = rarityWeights[r] * (1 + luckFactor);
+                    break;
+                }
+            }
+
+            return rarityWeights;
         }
 
         public static List<LootTable> GetLootTable(string objectName)
@@ -876,37 +885,6 @@ namespace EpicLoot
                     Debug.LogWarning($"{index++}: {player?.m_name}: {player?.m_nview?.GetZDO()?.GetInt("el-luk")}");
                 }
             }
-        }
-
-        public static Dictionary<ItemRarity, float> ModifyRarityByLuck(IReadOnlyDictionary<ItemRarity, float> rarityWeights, float luckFactor = 0)
-        {
-            var results = new Dictionary<ItemRarity, float>();
-            for (var rarity = ItemRarity.Magic; rarity <= ItemRarity.Legendary; rarity++)
-            {
-                var skewFactor = GetSkewFactor(rarity);
-                results.Add(rarity, rarityWeights[rarity] * GetSkewedLuckFactor(luckFactor, skewFactor));
-            }
-
-            return results;
-        }
-
-        public static float GetSkewFactor(ItemRarity rarity)
-        {
-            switch (rarity)
-            {
-                case ItemRarity.Magic: return -0.2f;
-                case ItemRarity.Rare: return 0.0f;
-                case ItemRarity.Epic: return 0.2f;
-                case ItemRarity.Legendary: return 1;
-                case ItemRarity.Mythic: return 1.1f;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(rarity), rarity, null);
-            }
-        }
-
-        public static float GetSkewedLuckFactor(float luckFactor, float skewFactor)
-        {
-            return Mathf.Max(0, 1 + luckFactor * skewFactor);
         }
 
         public static void PrintLuckTest(string lootTableName, float luckFactor)

--- a/EpicLoot/MagicItem.cs
+++ b/EpicLoot/MagicItem.cs
@@ -39,7 +39,7 @@ namespace EpicLoot
     [Serializable]
     public class MagicItem
     {
-        public int Version = 2;
+        public int Version = 3;
         public ItemRarity Rarity;
         public List<MagicItemEffect> Effects = new List<MagicItemEffect>();
         public string TypeNameOverride;
@@ -48,6 +48,7 @@ namespace EpicLoot
         public string DisplayName;
         public string LegendaryID;
         public string SetID;
+        public string ItemName;
 
         public string GetItemTypeName(ItemDrop.ItemData baseItem)
         {
@@ -71,7 +72,7 @@ namespace EpicLoot
             {
                 var effect = Effects[index];
                 var pip = EpicLoot.GetMagicEffectPip(IsEffectAugmented(index));
-                tooltip.AppendLine($"{pip} {GetEffectText(effect, Rarity, showRange)}");
+                tooltip.AppendLine($"{pip} {GetEffectText(effect, Rarity, ItemName, showRange)}");
             }
 
             tooltip.Append($"</color>");
@@ -127,11 +128,11 @@ namespace EpicLoot
             return result;
         }
 
-        public static string GetEffectText(MagicItemEffect effect, ItemRarity rarity, bool showRange, string legendaryID, MagicItemEffectDefinition.ValueDef valuesOverride)
+        public static string GetEffectText(MagicItemEffect effect, ItemRarity rarity, string itemName, bool showRange, string legendaryID, MagicItemEffectDefinition.ValueDef valuesOverride)
         {
             var effectDef = MagicItemEffectDefinitions.Get(effect.EffectType);
             var result = GetEffectText(effectDef, effect.EffectValue);
-            var values = valuesOverride ?? (string.IsNullOrEmpty(legendaryID) ? effectDef.GetValuesForRarity(rarity) : UniqueLegendaryHelper.GetLegendaryEffectValues(legendaryID, effect.EffectType));
+            var values = valuesOverride ?? (string.IsNullOrEmpty(legendaryID) ? effectDef.GetValuesForRarity(rarity, itemName) : UniqueLegendaryHelper.GetLegendaryEffectValues(legendaryID, effect.EffectType));
             if (showRange && values != null)
             {
                 if (!Mathf.Approximately(values.MinValue, values.MaxValue))
@@ -142,14 +143,14 @@ namespace EpicLoot
             return result;
         }
 
-        public static string GetEffectText(MagicItemEffect effect, ItemRarity rarity, bool showRange, string legendaryID = null)
+        public static string GetEffectText(MagicItemEffect effect, ItemRarity rarity, string itemName, bool showRange, string legendaryID = null)
         {
-            return GetEffectText(effect, rarity, showRange, legendaryID, null);
+            return GetEffectText(effect, rarity, itemName, showRange, legendaryID, null);
         }
 
-        public static string GetEffectText(MagicItemEffect effect, MagicItemEffectDefinition.ValueDef valuesOverride)
+        public static string GetEffectText(MagicItemEffect effect, string itemName, MagicItemEffectDefinition.ValueDef valuesOverride)
         {
-            return GetEffectText(effect, ItemRarity.Legendary, false, null, valuesOverride);
+            return GetEffectText(effect, ItemRarity.Legendary, itemName, false, null, valuesOverride);
         }
 
         public void ReplaceEffect(int index, MagicItemEffect newEffect)

--- a/EpicLoot/MagicItem.cs
+++ b/EpicLoot/MagicItem.cs
@@ -16,6 +16,13 @@ namespace EpicLoot
         Mythic
     }
 
+    public enum ItemQuality
+    {
+        Normal,
+        Exceptional,
+        Elite
+    }
+
     [Serializable]
     public class MagicItemEffect
     {
@@ -49,6 +56,7 @@ namespace EpicLoot
         public string LegendaryID;
         public string SetID;
         public string ItemName;
+        public ItemQuality Quality;
 
         public string GetItemTypeName(ItemDrop.ItemData baseItem)
         {
@@ -72,7 +80,7 @@ namespace EpicLoot
             {
                 var effect = Effects[index];
                 var pip = EpicLoot.GetMagicEffectPip(IsEffectAugmented(index));
-                tooltip.AppendLine($"{pip} {GetEffectText(effect, Rarity, ItemName, showRange, LegendaryID)}");
+                tooltip.AppendLine($"{pip} {GetEffectText(effect, Rarity, Quality, ItemName, showRange, LegendaryID)}");
             }
 
             tooltip.Append($"</color>");
@@ -128,7 +136,7 @@ namespace EpicLoot
             return result;
         }
 
-        public static string GetEffectText(MagicItemEffect effect, ItemRarity rarity, string itemName, bool showRange, string legendaryID, MagicItemEffectDefinition.ValueDef valuesOverride)
+        public static string GetEffectText(MagicItemEffect effect, ItemRarity rarity, ItemQuality quality, string itemName, bool showRange, string legendaryID, MagicItemEffectDefinition.ValueDef valuesOverride)
         {
             var effectDef = MagicItemEffectDefinitions.Get(effect.EffectType);
             var result = GetEffectText(effectDef, effect.EffectValue);
@@ -141,11 +149,11 @@ namespace EpicLoot
             {
                 if (!string.IsNullOrEmpty(legendaryID))
                 {
-                    values = UniqueLegendaryHelper.GetLegendaryEffectValues(legendaryID, effect.EffectType);
+                    values = UniqueLegendaryHelper.GetLegendaryEffectValues(legendaryID, effect.EffectType, quality);
                 }
                 if (values == null)
                 {
-                    values = effectDef.GetValuesForRarity(rarity, itemName);
+                    values = effectDef.GetValuesForRarity(rarity, itemName, quality);
                 }
             }
             if (showRange && values != null)
@@ -158,9 +166,9 @@ namespace EpicLoot
             return result;
         }
 
-        public static string GetEffectText(MagicItemEffect effect, ItemRarity rarity, string itemName, bool showRange, string legendaryID = null)
+        public static string GetEffectText(MagicItemEffect effect, ItemRarity rarity, ItemQuality quality, string itemName, bool showRange, string legendaryID = null)
         {
-            return GetEffectText(effect, rarity, itemName, showRange, legendaryID, null);
+            return GetEffectText(effect, rarity, quality, itemName, showRange, legendaryID, null);
         }
 
         public void ReplaceEffect(int index, MagicItemEffect newEffect)

--- a/EpicLoot/MagicItem.cs
+++ b/EpicLoot/MagicItem.cs
@@ -72,7 +72,7 @@ namespace EpicLoot
             {
                 var effect = Effects[index];
                 var pip = EpicLoot.GetMagicEffectPip(IsEffectAugmented(index));
-                tooltip.AppendLine($"{pip} {GetEffectText(effect, Rarity, ItemName, showRange)}");
+                tooltip.AppendLine($"{pip} {GetEffectText(effect, Rarity, ItemName, showRange, LegendaryID)}");
             }
 
             tooltip.Append($"</color>");
@@ -132,7 +132,22 @@ namespace EpicLoot
         {
             var effectDef = MagicItemEffectDefinitions.Get(effect.EffectType);
             var result = GetEffectText(effectDef, effect.EffectValue);
-            var values = valuesOverride ?? (string.IsNullOrEmpty(legendaryID) ? effectDef.GetValuesForRarity(rarity, itemName) : UniqueLegendaryHelper.GetLegendaryEffectValues(legendaryID, effect.EffectType));
+            MagicItemEffectDefinition.ValueDef values = null;
+            if (valuesOverride != null)
+            {
+                values = valuesOverride;
+            }
+            else
+            {
+                if (!string.IsNullOrEmpty(legendaryID))
+                {
+                    values = UniqueLegendaryHelper.GetLegendaryEffectValues(legendaryID, effect.EffectType);
+                }
+                if (values == null)
+                {
+                    values = effectDef.GetValuesForRarity(rarity, itemName);
+                }
+            }
             if (showRange && values != null)
             {
                 if (!Mathf.Approximately(values.MinValue, values.MaxValue))
@@ -146,11 +161,6 @@ namespace EpicLoot
         public static string GetEffectText(MagicItemEffect effect, ItemRarity rarity, string itemName, bool showRange, string legendaryID = null)
         {
             return GetEffectText(effect, rarity, itemName, showRange, legendaryID, null);
-        }
-
-        public static string GetEffectText(MagicItemEffect effect, string itemName, MagicItemEffectDefinition.ValueDef valuesOverride)
-        {
-            return GetEffectText(effect, ItemRarity.Legendary, itemName, false, null, valuesOverride);
         }
 
         public void ReplaceEffect(int index, MagicItemEffect newEffect)

--- a/EpicLoot/MagicItemComponent.cs
+++ b/EpicLoot/MagicItemComponent.cs
@@ -264,13 +264,33 @@ namespace EpicLoot
         public static string GetDecoratedName(this ItemDrop.ItemData itemData, string colorOverride = null)
         {
             var color = "white";
+
+            var magicItem = itemData.GetMagicItem();
+            var qualityStr = "";
+            if (magicItem != null)
+            {
+                var quality = magicItem.Quality;
+                if (quality == ItemQuality.Elite)
+                {
+                    qualityStr = Localization.instance.Localize("$mod_epicloot_elite");
+                }
+                else if (quality == ItemQuality.Exceptional)
+                {
+                    qualityStr = Localization.instance.Localize("$mod_epicloot_exceptional");
+                }
+                if (qualityStr != "")
+                {
+                    qualityStr = qualityStr + " ";
+                }
+            }
+
             var name = GetDisplayName(itemData);
 
             if (!string.IsNullOrEmpty(colorOverride))
             {
                 color = colorOverride;
             }
-            else if (itemData.IsMagic(out var magicItem))
+            else if (magicItem != null)
             {
                 color = magicItem.GetColorString();
             }
@@ -279,7 +299,7 @@ namespace EpicLoot
                 color = itemData.GetCraftingMaterialRarityColor();
             }
 
-            return $"<color={color}>{name}</color>";
+            return $"<color={color}>{qualityStr}{name}</color>";
         }
 
         public static string GetDescription(this ItemDrop.ItemData itemData)

--- a/EpicLoot/MagicItemEffectDefinition.cs
+++ b/EpicLoot/MagicItemEffectDefinition.cs
@@ -300,12 +300,20 @@ namespace EpicLoot
             public ValueDef Mythic;
         }
 
+        [Serializable]
+        public class ValuesPerItemNameDef
+        {
+            public List<string> ItemNames = new List<string>();
+            public ValuesPerRarityDef ValuesPerRarity = new ValuesPerRarityDef();
+        }
+
         public string Type { get; set; }
 
         public string DisplayText = "";
         public string Description = "";
         public MagicItemEffectRequirements Requirements = new MagicItemEffectRequirements();
         public ValuesPerRarityDef ValuesPerRarity = new ValuesPerRarityDef();
+        public List<ValuesPerItemNameDef> ValuesPerItemName = new List<ValuesPerItemNameDef>();
         public float SelectionWeight = 1;
         public bool CanBeAugmented = true;
         public bool CanBeDisenchanted = true;
@@ -338,18 +346,36 @@ namespace EpicLoot
 
         public ValueDef GetValuesForRarity(ItemRarity itemRarity, string itemName)
         {
-            switch (itemRarity)
+            ValueDef ValueForRarity(ValuesPerRarityDef valuesPerRarity)
             {
-                case ItemRarity.Magic:      return ValuesPerRarity.Magic;
-                case ItemRarity.Rare:       return ValuesPerRarity.Rare;
-                case ItemRarity.Epic:       return ValuesPerRarity.Epic;
-                case ItemRarity.Legendary:  return ValuesPerRarity.Legendary;
-                case ItemRarity.Mythic:
-                    // TODO: Mythic Hookup
-                    return null;//ValuesPerRarity.Mythic;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(itemRarity), itemRarity, null);
+                switch (itemRarity)
+                {
+                    case ItemRarity.Magic: return valuesPerRarity.Magic;
+                    case ItemRarity.Rare: return valuesPerRarity.Rare;
+                    case ItemRarity.Epic: return valuesPerRarity.Epic;
+                    case ItemRarity.Legendary: return valuesPerRarity.Legendary;
+                    case ItemRarity.Mythic:
+                        // TODO: Mythic Hookup
+                        return null;//ValuesPerRarity.Mythic;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(itemRarity), itemRarity, null);
+                }
             }
+
+            if (string.IsNullOrEmpty(itemName) || ValuesPerItemName == null)
+            {
+                return ValueForRarity(ValuesPerRarity);
+            }
+
+            for (var i = 0; i < ValuesPerItemName.Count; i++)
+            {
+                if (ValuesPerItemName[i].ItemNames.Contains(itemName))
+                {
+                    return ValueForRarity(ValuesPerItemName[i].ValuesPerRarity);
+                }
+            }
+
+            return ValueForRarity(ValuesPerRarity);
         }
     }
 

--- a/EpicLoot/MagicItemEffectDefinition.cs
+++ b/EpicLoot/MagicItemEffectDefinition.cs
@@ -336,7 +336,7 @@ namespace EpicLoot
             return ValuesPerRarity.Magic != null && ValuesPerRarity.Epic != null && ValuesPerRarity.Rare != null && ValuesPerRarity.Legendary != null;
         }
 
-        public ValueDef GetValuesForRarity(ItemRarity itemRarity)
+        public ValueDef GetValuesForRarity(ItemRarity itemRarity, string itemName)
         {
             switch (itemRarity)
             {
@@ -426,7 +426,7 @@ namespace EpicLoot
                 return false;
             }
 
-            return effectDef.GetValuesForRarity(rarity) == null;
+            return effectDef.GetValuesForRarity(rarity, null) == null;
         }
     }
 }

--- a/EpicLoot/Multiplayer_Player_Patch.cs
+++ b/EpicLoot/Multiplayer_Player_Patch.cs
@@ -119,7 +119,7 @@ namespace EpicLoot
                     itemData = targetItemData.Clone();
                     itemData.m_durability = float.PositiveInfinity;
                     var magicItemComponent = itemData.Data().GetOrCreate<MagicItemComponent>();
-                    var stubMagicItem = new MagicItem { Rarity = ItemRarity.Legendary, LegendaryID = zdoLegendaryID };
+                    var stubMagicItem = new MagicItem { Rarity = ItemRarity.Legendary, ItemName = itemData.m_shared.m_name, LegendaryID = zdoLegendaryID };
                     magicItemComponent.SetMagicItem(stubMagicItem);
 
                     ForceResetVisEquipment(player, itemData);

--- a/EpicLoot/Terminal_Patch.cs
+++ b/EpicLoot/Terminal_Patch.cs
@@ -618,7 +618,7 @@ namespace EpicLoot
                 return;
             }
 
-            var replacementEffect = LootRoller.RollEffect(replacementEffectDef, magicItem.Rarity);
+            var replacementEffect = LootRoller.RollEffect(replacementEffectDef, magicItem.Rarity, itemData.m_shared.m_name);
             magicItem.Effects[index] = replacementEffect;
             itemData.SaveMagicItem(magicItem);
         }

--- a/EpicLoot/Terminal_Patch.cs
+++ b/EpicLoot/Terminal_Patch.cs
@@ -186,7 +186,8 @@ namespace EpicLoot
                 var lootTable = args.Length > 1 ? args[1] : "Greydwarf";
                 var level = args.Length > 2 ? int.Parse(args[2]) : 1;
                 var itemIndex = args.Length > 3 ? int.Parse(args[3]) : 0;
-                LootRoller.PrintLootResolutionTest(lootTable, level, itemIndex);
+                var distance = args.Length > 4 ? int.Parse(args[4]) : 0;
+                LootRoller.PrintLootResolutionTest(lootTable, level, distance, itemIndex);
             }));
             new Terminal.ConsoleCommand("resetcooldowns", "", (args =>
             {

--- a/EpicLoot/Terminal_Patch.cs
+++ b/EpicLoot/Terminal_Patch.cs
@@ -618,7 +618,7 @@ namespace EpicLoot
                 return;
             }
 
-            var replacementEffect = LootRoller.RollEffect(replacementEffectDef, magicItem.Rarity, itemData.m_shared.m_name);
+            var replacementEffect = LootRoller.RollEffect(replacementEffectDef, magicItem.Rarity, magicItem.Quality, itemData.m_shared.m_name);
             magicItem.Effects[index] = replacementEffect;
             itemData.SaveMagicItem(magicItem);
         }

--- a/EpicLoot/TextsDialog_Patch.cs
+++ b/EpicLoot/TextsDialog_Patch.cs
@@ -64,7 +64,7 @@ namespace EpicLoot
                 {
                     var effect = entry2.Key;
                     var item = entry2.Value;
-                    t.AppendLine($" <color=#c0c0c0ff>- {MagicItem.GetEffectText(effect, item.GetRarity(), false)} ({item.GetDecoratedName()})</color>");
+                    t.AppendLine($" <color=#c0c0c0ff>- {MagicItem.GetEffectText(effect, item.GetRarity(), item.m_shared.m_name, false)} ({item.GetDecoratedName()})</color>");
                 }
 
                 t.AppendLine();

--- a/EpicLoot/TextsDialog_Patch.cs
+++ b/EpicLoot/TextsDialog_Patch.cs
@@ -65,7 +65,7 @@ namespace EpicLoot
                     var effect = entry2.Key;
                     var item = entry2.Value;
                     var magicItem = item.GetMagicItem();
-                    t.AppendLine($" <color=#c0c0c0ff>- {MagicItem.GetEffectText(effect, item.GetRarity(), item.m_shared.m_name, false, magicItem?.LegendaryID)} ({item.GetDecoratedName()})</color>");
+                    t.AppendLine($" <color=#c0c0c0ff>- {MagicItem.GetEffectText(effect, item.GetRarity(), magicItem != null ? magicItem.Quality : ItemQuality.Normal, item.m_shared.m_name, false, magicItem?.LegendaryID)} ({item.GetDecoratedName()})</color>");
                 }
 
                 t.AppendLine();

--- a/EpicLoot/TextsDialog_Patch.cs
+++ b/EpicLoot/TextsDialog_Patch.cs
@@ -64,7 +64,8 @@ namespace EpicLoot
                 {
                     var effect = entry2.Key;
                     var item = entry2.Value;
-                    t.AppendLine($" <color=#c0c0c0ff>- {MagicItem.GetEffectText(effect, item.GetRarity(), item.m_shared.m_name, false)} ({item.GetDecoratedName()})</color>");
+                    var magicItem = item.GetMagicItem();
+                    t.AppendLine($" <color=#c0c0c0ff>- {MagicItem.GetEffectText(effect, item.GetRarity(), item.m_shared.m_name, false, magicItem?.LegendaryID)} ({item.GetDecoratedName()})</color>");
                 }
 
                 t.AppendLine();

--- a/EpicLoot/lootfilters.json
+++ b/EpicLoot/lootfilters.json
@@ -5,7 +5,7 @@
     //   "Name": "Magic loot filter", - name of the filter for the reference
     //   "Whitelist": false, - if set to true, the filter works in the opposite way, that is, the matching item will be dropped even if should be filtered out by other loot filters
     //   "DropMaterials": true, - if set to true, the item materials will be dropped instead of the item itself, if set to false, there will be no drop at all
-    //   "Items": [], - list of any "Name" fields from loottables.json
+    //   "Items": [], - list of item names (check "Item" fields used in loottables.json)
     //   "Rarities" : [
     //     "Magic",
     //     "Rare",
@@ -18,8 +18,7 @@
     //     "Elite"
     //   ],
     //   "Distance": 0, - minimal distance from the center of the world for the filter to be applied
-    //   "Day": 0, - minimal day in the world for the filter to be applied
-    //   "ApplyToChests": true - if set to true, chests items also affected
+    //   "Day": 0, - minimal day in the world for the filter to be applied, NOT IMPLEMENTED YET
     // }
     {
       "Name": "Tier0Everything - Normal",
@@ -35,7 +34,7 @@
         "ShieldWood",
         "ShieldWoodTower"
       ],
-      "Rarities" : [
+      "Rarities": [
         "Magic",
         "Rare",
         "Epic"
@@ -43,8 +42,7 @@
       "Quality": [
         "Normal"
       ],
-      "Distance": 3500,
-      "ApplyToChests": true
+      "Distance": 3500
     },
     {
       "Name": "Tier1Everything - Normal",
@@ -61,7 +59,7 @@
         "PickaxeAntler",
         "ShieldBoneTower"
       ],
-      "Rarities" : [
+      "Rarities": [
         "Magic",
         "Rare",
         "Epic"
@@ -69,8 +67,7 @@
       "Quality": [
         "Normal"
       ],
-      "Distance": 3500,
-      "ApplyToChests": true
+      "Distance": 3500
     },
     {
       "Name": "Tier2Everything - Normal",
@@ -97,7 +94,7 @@
         "PickaxeBronze",
         "Cultivator"
       ],
-      "Rarities" : [
+      "Rarities": [
         "Magic",
         "Rare",
         "Epic"
@@ -105,8 +102,7 @@
       "Quality": [
         "Normal"
       ],
-      "Distance": 5000,
-      "ApplyToChests": true
+      "Distance": 5000
     }
   ]
 }

--- a/EpicLoot/lootfilters.json
+++ b/EpicLoot/lootfilters.json
@@ -1,0 +1,112 @@
+{
+  "LootFilters": [
+    // example
+    // {
+    //   "Name": "Magic loot filter", - name of the filter for the reference
+    //   "Whitelist": false, - if set to true, the filter works in the opposite way, that is, the matching item will be dropped even if should be filtered out by other loot filters
+    //   "DropMaterials": true, - if set to true, the item materials will be dropped instead of the item itself, if set to false, there will be no drop at all
+    //   "Items": [], - list of any "Name" fields from loottables.json
+    //   "Rarities" : [
+    //     "Magic",
+    //     "Rare",
+    //     "Epic",
+    //     "Legendary"
+    //   ],
+    //   "Quality": [
+    //     "Normal",
+    //     "Exceptional",
+    //     "Elite"
+    //   ],
+    //   "Distance": 0, - minimal distance from the center of the world for the filter to be applied
+    //   "Day": 0, - minimal day in the world for the filter to be applied
+    //   "ApplyToChests": true - if set to true, chests items also affected
+    // }
+    {
+      "Name": "Tier0Everything - Normal",
+      "DropMaterials": true,
+      "Items": [
+        "Club",
+        "AxeStone",
+        "Torch",
+        "Hammer",
+        "Hoe",
+        "ArmorRagsLegs",
+        "ArmorRagsChest",
+        "ShieldWood",
+        "ShieldWoodTower"
+      ],
+      "Rarities" : [
+        "Magic",
+        "Rare",
+        "Epic"
+      ],
+      "Quality": [
+        "Normal"
+      ],
+      "Distance": 3500,
+      "ApplyToChests": true
+    },
+    {
+      "Name": "Tier1Everything - Normal",
+      "DropMaterials": true,
+      "Items": [
+        "AxeFlint",
+        "SpearFlint",
+        "KnifeFlint",
+        "Bow",
+        "ArmorLeatherLegs",
+        "ArmorLeatherChest",
+        "HelmetLeather",
+        "CapeDeerHide",
+        "PickaxeAntler",
+        "ShieldBoneTower"
+      ],
+      "Rarities" : [
+        "Magic",
+        "Rare",
+        "Epic"
+      ],
+      "Quality": [
+        "Normal"
+      ],
+      "Distance": 3500,
+      "ApplyToChests": true
+    },
+    {
+      "Name": "Tier2Everything - Normal",
+      "DropMaterials": true,
+      "Items": [
+        "ArmorTrollLeatherLegs",
+        "ArmorTrollLeatherChest",
+        "HelmetTrollLeather",
+        "CapeTrollHide",
+        "KnifeCopper",
+        "SledgeStagbreaker",
+        "SwordBronze",
+        "AxeBronze",
+        "MaceBronze",
+        "AtgeirBronze",
+        "SpearBronze",
+        "BowFineWood",
+        "KnifeChitin",
+        "SpearChitin",
+        "ArmorBronzeLegs",
+        "ArmorBronzeChest",
+        "HelmetBronze",
+        "ShieldBronzeBuckler",
+        "PickaxeBronze",
+        "Cultivator"
+      ],
+      "Rarities" : [
+        "Magic",
+        "Rare",
+        "Epic"
+      ],
+      "Quality": [
+        "Normal"
+      ],
+      "Distance": 5000,
+      "ApplyToChests": true
+    }
+  ]
+}

--- a/EpicLoot/loottables.json
+++ b/EpicLoot/loottables.json
@@ -1456,6 +1456,16 @@
       "Loot": [
         { "Item": "Tier0Everything", "Weight": 4, "Rarity": [ 97, 2, 1, 0] },
         { "Item": "Tier1Everything", "Weight": 1, "Rarity": [ 97, 2, 1, 0] }
+      ],
+      "DistanceLoot": [
+        {
+          "Distance": 4000,
+          "Drops": [ [0, 40], [1, 38], [2, 20], [3, 2] ],
+          "Loot": [
+            { "Item": "Tier0Everything", "Weight": 4, "Rarity": [ 97, 2, 1, 0] },
+            { "Item": "Tier1Everything", "Weight": 1, "Rarity": [ 97, 2, 1, 0] }
+          ]
+        }
       ]
     },
     //TreasureChest_blackforest

--- a/EpicLoot/translations.json
+++ b/EpicLoot/translations.json
@@ -99,7 +99,7 @@
   "mod_epicloot_effectsperlevel": "Upgrades:",
   "mod_epicloot_upgrademessage": "$1 upgraded to level $2",
   "mod_epicloot_unlockmessage": "$1 upgraded to level $2",
-  "mod_epicloot_bonus": "Bonus!", 
+  "mod_epicloot_bonus": "Bonus!",
 
   "mod_epicloot_featureinfo_none": "Select a feature from the list to the left to view upgrade options.",
   "mod_epicloot_featureinfo_sacrifice": "Sacrifice magic items and trophies, destroying them to produce enchanting materials.\n\nWhen upgraded, gain a chance to recieve double the items normally gained from the sacrifice.",
@@ -1254,5 +1254,7 @@
   "mod_epicloot_rare": "Rare",
   "mod_epicloot_epic": "Epic",
   "mod_epicloot_legendary": "Legendary",
-  "mod_epicloot_legendarysetlabel": "Legendary Set Item"
+  "mod_epicloot_legendarysetlabel": "Legendary Set Item",
+  "mod_epicloot_exceptional": "Exceptional",
+  "mod_epicloot_elite": "Elite"
 }


### PR DESCRIPTION
Motivation: loot filters are important part of the games with reach loot system. For "the origin" Diablo 2 many third party software has been specifically implemented for the purpose, as for many more modern games, they have provided loot filter from a box. For Valheim (with item cluttering being one of the biggest not solved problem of the game design in it), the possibility to reduce potential cluttering is vital.

What has been implemented:
- "Use Loot Filters" configuration setting to turn loot filters on/off
- configuration file "lootfilters.json" that allows users to create/update lists of blacklist/whitelist loot filters
- logic of filters usage

Blacklist filters can be configured to prevent specific items from dropping completely or to auto convert the matching items to materials. Whitelists prevent items from matching to any blacklist.
Each filter has the following configuration properties:
- "Items" - list of item names to match
- "DropMaterials" - whether to convert the item to materials or not drop at all
- "Rarities" - what item rarities are affected
- "Quality" - what item qualities are affected
- "Distance" - distance from the center of the world the filter starts to be applied from

Not implemented but potentially usefull to implement is "Day" property which can control day of the world the filter starts to be applied from (to match CreatureLevelControl alternative world level setting).

Backward compatibility: similar to ItemName filter, requires FominArtmind:pr-item-name-in-magic-item, FominArtmind:pr-quality-of-items, FominArtmind:pr-loottables-distance-config, FominArtmind:pr-changed-item-gating-to-replacing-with-materials to be accepted first to avoid merge conflicts.