### PR TITLE
Adding some offhand torch effects to the weapon

### DIFF
--- a/EpicLoot/MagicItemEffects/AddLifeSteal.cs
+++ b/EpicLoot/MagicItemEffects/AddLifeSteal.cs
@@ -40,7 +40,7 @@ namespace EpicLoot.MagicItemEffects
                     return;
 
                 var lifeStealMultiplier = 0f;
-                ModifyWithLowHealth.Apply(player, MagicEffectType.LifeSteal, effect => lifeStealMultiplier += MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, weapon, effect, 0.01f));
+                ModifyWithLowHealth.Apply(player, MagicEffectType.LifeSteal, effect => lifeStealMultiplier += MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, weapon, effect, 0.01f, true));
 
                 if (lifeStealMultiplier == 0)
 	                return;

--- a/EpicLoot/MagicItemEffects/Executioner.cs
+++ b/EpicLoot/MagicItemEffects/Executioner.cs
@@ -71,7 +71,7 @@ namespace EpicLoot.MagicItemEffects
         {
             float totalMagicEffect;
             if (Attack_Patch.ActiveAttack != null)
-                totalMagicEffect = MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, Attack_Patch.ActiveAttack.m_weapon, MagicEffectType.Executioner, 0.01f);
+                totalMagicEffect = MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, Attack_Patch.ActiveAttack.m_weapon, MagicEffectType.Executioner, 0.01f, true);
             else
                 totalMagicEffect = player.GetTotalActiveMagicEffectValue(MagicEffectType.Executioner, 0.01f);
             return 1 + totalMagicEffect;

--- a/EpicLoot/MagicItemEffects/MagicEffectsHelper.cs
+++ b/EpicLoot/MagicItemEffects/MagicEffectsHelper.cs
@@ -41,20 +41,34 @@ namespace EpicLoot.MagicItemEffects
             }
         }
 
-        private static ItemDrop.ItemData GetIgnoreWeapon(Player player, ItemDrop.ItemData equippedWeapon)
+        private static bool IsTorch(ItemDrop.ItemData itemData)
         {
-            if (player.m_rightItem == equippedWeapon && IsWeapon(player.m_leftItem))
+            if (itemData == null)
+                return false;
+
+            switch (itemData.m_shared.m_itemType)
+            {
+                case ItemDrop.ItemData.ItemType.Torch:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static ItemDrop.ItemData GetIgnoreWeapon(Player player, ItemDrop.ItemData equippedWeapon, bool excludeTorch = false)
+        {
+            if (player.m_rightItem == equippedWeapon && IsWeapon(player.m_leftItem) && (!excludeTorch || !IsTorch(player.m_leftItem)))
                 return player.m_leftItem;
-            if (player.m_leftItem == equippedWeapon && IsWeapon(player.m_rightItem))
+            if (player.m_leftItem == equippedWeapon && IsWeapon(player.m_rightItem) && (!excludeTorch || !IsTorch(player.m_rightItem)))
                 return player.m_rightItem;
 
             return null;
         }
 
-        public static float GetTotalActiveMagicEffectValueForWeapon(Player player, ItemDrop.ItemData itemData, string effectType, float scale = 1.0f)
+        public static float GetTotalActiveMagicEffectValueForWeapon(Player player, ItemDrop.ItemData itemData, string effectType, float scale = 1.0f, bool addOffhandTorchEffects = false)
         {
             if (player != null)
-                return player.GetTotalActiveMagicEffectValue(effectType, scale, GetIgnoreWeapon(player, itemData));
+                return player.GetTotalActiveMagicEffectValue(effectType, scale, GetIgnoreWeapon(player, itemData, addOffhandTorchEffects));
             if (itemData.IsMagic(out var magicItem))
                 return magicItem.GetTotalEffectValue(effectType, scale);
             return 0;

--- a/EpicLoot/MagicItemEffects/ModifyBackstab.cs
+++ b/EpicLoot/MagicItemEffects/ModifyBackstab.cs
@@ -45,7 +45,7 @@ namespace EpicLoot.MagicItemEffects
                 Override = true;
                 OriginalValue = weapon.m_shared.m_backstabBonus;
 
-                var totalBackstabMod = MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance.m_weapon, MagicEffectType.ModifyBackstab, 0.01f);
+                var totalBackstabMod = MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance.m_weapon, MagicEffectType.ModifyBackstab, 0.01f, true);
                 weapon.m_shared.m_backstabBonus *= 1.0f + totalBackstabMod;
             }
 

--- a/EpicLoot/MagicItemEffects/ModifyDamage.cs
+++ b/EpicLoot/MagicItemEffects/ModifyDamage.cs
@@ -31,18 +31,18 @@ namespace EpicLoot.MagicItemEffects
             var player = PlayerExtensions.GetPlayerWithEquippedItem(__instance);
 
             // Add damages first
-            __result.m_blunt        += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddBluntDamage);
-            __result.m_slash        += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddSlashingDamage);
-            __result.m_pierce       += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddPiercingDamage);
-            __result.m_fire         += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddFireDamage);
-            __result.m_frost        += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddFrostDamage);
-            __result.m_lightning    += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddLightningDamage);
-            __result.m_poison       += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddPoisonDamage);
-            __result.m_spirit       += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddSpiritDamage);
+            __result.m_blunt        += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddBluntDamage, 1.0f, true);
+            __result.m_slash        += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddSlashingDamage, 1.0f, true);
+            __result.m_pierce       += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddPiercingDamage, 1.0f, true);
+            __result.m_fire         += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddFireDamage, 1.0f, true);
+            __result.m_frost        += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddFrostDamage, 1.0f, true);
+            __result.m_lightning    += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddLightningDamage, 1.0f, true);
+            __result.m_poison       += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddPoisonDamage, 1.0f, true);
+            __result.m_spirit       += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddSpiritDamage, 1.0f, true);
             
             if (magicItemskillType == Skills.SkillType.Axes)
             {
-                __result.m_chop += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddSlashingDamage);
+                __result.m_chop += totalDamage * MagicEffectsHelper.GetTotalActiveMagicEffectValueForWeapon(player, __instance, MagicEffectType.AddSlashingDamage, 1.0f, true);
             }
             else if (magicItemskillType == Skills.SkillType.Pickaxes)
             {


### PR DESCRIPTION
Motivation: Most of magic effects (damage, lifesteal etc) work from any items equipped (armor, utility). There is no big sense of using this behavior for ordinary magic, rare or epic items (especially for the current state of Epic Loot where you can't set effect values for an individual item, that is, one value for weapon and other value for armor) and the default magic effect configuration naturally doesn't set any "add damage" effects for non-weapon items, but for unique legendaries the behavior provides incredible opportunities. Example from possible legendaries.json:
```
    {
        "ID": "RisingSun",
        "Name": "$mod_epicloot_l_rising_sun",
        "Description": "$mod_epicloot_l_rising_sun_desc",
        "Requirements": {
            "AllowedItemNames": [ "$item_shield_bronzebuckler" ]
        },
        "SelectionWeight": 10000,
        "GuaranteedEffectCount": 6,
        "GuaranteedMagicEffects": [
            { "Type": "ModifyParry", "Values": { "MinValue": 65, "MaxValue": 65, "Increment": 1 } },
            { "Type": "AddFireDamage", "Values": { "MinValue": 15, "MaxValue": 15, "Increment": 1 } },
            { "Type": "AddSpiritDamage", "Values": { "MinValue": 15, "MaxValue": 15, "Increment": 1 } },
            { "Type": "ModifyBlockStaminaUse", "Values": { "MinValue": 35, "MaxValue": 50, "Increment": 1 } },
            { "Type": "RemoveSpeedPenalty" },
            { "Type": "Indestructible" }
        ]
}
```

However, off-hand torches are basically the only type of items excluded from the possibility to add such effects despite being the first candidate to have it (you either carry a shield with all of its bonuses or you carry a torch and should also get bonuses from that).
The following changes are implemented:
- "add [particular damage type] damage" effects from offhand torch are added to the weapon
- "add physical/elemental damage" effects from offhand torch are NOT added to the weapon providing control on torch own damage/torch bonuses for the weapon ratio
- some additional effects like lifesteal, backstab also added from offhand torch to the weapon

Example from possible legendaries.json:
```
    {
        "ID": "FireClub",
        "Name": "$mod_epicloot_l_fire_club",
        "Description": "$mod_epicloot_l_fire_club_desc",
        "Requirements": {
            "AllowedItemNames": [ "$item_torch" ]
        },
        "SelectionWeight": 2500,
        "GuaranteedEffectCount": 5,
        "GuaranteedMagicEffects": [
            { "Type": "ModifyElementalDamage", "Values": { "MinValue": 60, "MaxValue": 90, "Increment": 1 } },
            { "Type": "AddFireDamage", "Values": { "MinValue": 30, "MaxValue": 60, "Increment": 1 } },
            { "Type": "ModifyMovementSpeed", "Values": { "MinValue": 6, "MaxValue": 13, "Increment": 1 } },
            { "Type": "RemoveSpeedPenalty" },
            { "Type": "Indestructible" }
        ]
}
```
That is, the torch having own fire damage increased by 90-150% but being in offhand increases weapon fire damage only by 30-60%.

Backward compatibility: should be full