### PR TITLE
Rerolling default items on container first opening/destroy without opening

### DIFF
--- a/EpicLoot/Container_Patch.cs
+++ b/EpicLoot/Container_Patch.cs
@@ -7,6 +7,17 @@ namespace EpicLoot
     [HarmonyPatch(typeof(Container), nameof(Container.AddDefaultItems))]
     public static class Container_AddDefaultItems_Patch
     {
+        // already created (on Awake call) default items should be removed first 
+        public static void Prefix(Container __instance)
+        {
+            if (__instance == null || __instance.m_piece == null)
+            {
+                return;
+            }
+
+            __instance.m_inventory.RemoveAll();
+        }
+
         public static void Postfix(Container __instance)
         {
             if (__instance == null || __instance.m_piece == null)
@@ -25,6 +36,45 @@ namespace EpicLoot
                     __instance.m_inventory.AddItem(item);
                     EpicLoot.Log($"  - {item.m_shared.m_name}" + (item.IsMagic() ? $": {string.Join(", ", item.GetMagicItem().Effects.Select(x => x.EffectType.ToString()))}" : ""));
                 }
+            }
+        }
+    }
+
+    // Looks like there is no need to change this since all containers are not empty initially
+    // [HarmonyPatch(typeof(Container), nameof(Container.GetHoverText))]
+
+    [HarmonyPatch(typeof(Container), nameof(Container.RPC_RequestOpen))]
+    public static class Container_RPC_RequestOpen_Patch
+    {
+        public static void Prefix(Container __instance, long uid, long playerID)
+        {
+            if (__instance == null || __instance.m_piece == null)
+            {
+                return;
+            }
+
+            if (__instance.m_nview.IsOwner() && !__instance.m_nview.GetZDO().GetBool("EL_container_items_rolled".GetStableHashCode()))
+            {
+                __instance.AddDefaultItems();
+                __instance.m_nview.GetZDO().Set("EL_container_items_rolled".GetStableHashCode(), value: true);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(Container), nameof(Container.OnDestroyed))]
+    public static class Container_OnDestroyed_Patch
+    {
+        public static void Prefix(Container __instance)
+        {
+            if (__instance == null || __instance.m_piece == null)
+            {
+                return;
+            }
+
+            if (__instance.m_nview.IsOwner() && !__instance.m_nview.GetZDO().GetBool("EL_container_items_rolled".GetStableHashCode()))
+            {
+                __instance.AddDefaultItems();
+                __instance.m_nview.GetZDO().Set("EL_container_items_rolled".GetStableHashCode(), value: true);
             }
         }
     }

--- a/EpicLoot/Container_Patch.cs
+++ b/EpicLoot/Container_Patch.cs
@@ -15,7 +15,12 @@ namespace EpicLoot
                 return;
             }
 
-            __instance.m_inventory.RemoveAll();
+            var containerName = __instance.m_piece.name.Replace("(Clone)", "").Trim();
+            var lootTables = LootRoller.GetLootTable(containerName);
+            if (lootTables != null && lootTables.Count > 0)
+            {
+                __instance.m_inventory.RemoveAll();
+            }
         }
 
         public static void Postfix(Container __instance)

--- a/EpicLoot/Container_Patch.cs
+++ b/EpicLoot/Container_Patch.cs
@@ -55,7 +55,12 @@ namespace EpicLoot
 
             if (__instance.m_nview.IsOwner() && !__instance.m_nview.GetZDO().GetBool("EL_container_items_rolled".GetStableHashCode()))
             {
-                __instance.AddDefaultItems();
+                var containerName = __instance.m_piece.name.Replace("(Clone)", "").Trim();
+                var lootTables = LootRoller.GetLootTable(containerName);
+                if (lootTables != null && lootTables.Count > 0)
+                {
+                    __instance.AddDefaultItems();
+                }
                 __instance.m_nview.GetZDO().Set("EL_container_items_rolled".GetStableHashCode(), value: true);
             }
         }
@@ -73,7 +78,12 @@ namespace EpicLoot
 
             if (__instance.m_nview.IsOwner() && !__instance.m_nview.GetZDO().GetBool("EL_container_items_rolled".GetStableHashCode()))
             {
-                __instance.AddDefaultItems();
+                var containerName = __instance.m_piece.name.Replace("(Clone)", "").Trim();
+                var lootTables = LootRoller.GetLootTable(containerName);
+                if (lootTables != null && lootTables.Count > 0)
+                {
+                    __instance.AddDefaultItems();
+                }
                 __instance.m_nview.GetZDO().Set("EL_container_items_rolled".GetStableHashCode(), value: true);
             }
         }


### PR DESCRIPTION
Motivation: There is a big issue in world containers item generation and Item Drop Limits flag interaction (BossKillUnlocksCurrentBiomeItems, BossKillUnlocksNextBiomeItems, PlayerMustKnowRecipe, PlayerMustHaveCraftedItem values) due to the latter forcing items not available yet to gate (or break into reagents). Currently, items are added in chests the same moment the default items added by the game, that is, when Awake() method is called for the chest. That happens "too early" (since Awake() can be called for the chest being far away from the player, in other biome, in dungeon the player can't access yet etc - all cases approved by testing) resulting in player "spoiling" chests just by their accident presence.
According to the tests, Awake() is being called once for every chest and not being called again on new game session.
Thus, the proposed solution is to add a new flag that checks whether the player has ever opened the chest and use the flag to roll items again on the first chest opening or on the first destroying without opening. Default items are still being added on Awake to have a proper chest hint (that the chest is not empty) before the first opening. However, the chest is cleared every time before adding the default items to avoid double generation.

Backward compatibility: can have incorrect interaction with other mods changing chest behavior